### PR TITLE
fix(filter): malformed conditions no longer crash the Shiny session (JS-sync containment)

### DIFF
--- a/R/js-block.R
+++ b/R/js-block.R
@@ -166,12 +166,26 @@ js_block_state <- function(input, session, name, input_name, state,
     if (self_write$active) {
       self_write$active <- FALSE
     } else {
-      session$sendCustomMessage(
-        paste0(name, "-block-update"),
-        list(
-          id = session$ns(input_name),
-          state = normalize_state(r_state())
-        )
+      # This observer runs OUTSIDE blockr.core's per-block error boundary
+      # (which only wraps expr eval / data / render), so a throw in
+      # `normalize_state()` or serialization is session-fatal rather than
+      # contained to the block. No block's state sync may ever take down the
+      # whole session -- contain it and warn so the block degrades instead.
+      tryCatch(
+        session$sendCustomMessage(
+          paste0(name, "-block-update"),
+          list(
+            id = session$ns(input_name),
+            state = normalize_state(r_state())
+          )
+        ),
+        error = function(e) {
+          warning(
+            sprintf("blockr.dplyr: could not sync '%s' state to JS: %s",
+                    name, conditionMessage(e)),
+            call. = FALSE
+          )
+        }
       )
     }
   })


### PR DESCRIPTION
Closes #80.

Completes the malformed-`conditions` crash containment. The earlier layers
already landed on `main` (via the broader filter/dplyr hardening):

- `normalize_filter_state_for_js` `is.list()` defense — `b39a4e8`, on main.
- `make_filter_part` / preserve-order skip of non-list / typeless conditions
  (`R/expr-builders.R`) — on main.
- malformed-conditions tests (`tests/testthat/test-filter.R`) — on main.

**Net-new here:** wrap the `js_block_state` R→JS state push (`sendCustomMessage`)
in `tryCatch`. That observer runs **outside** blockr.core's per-block error
boundary, so a throw in `normalize_state()`/serialization was session-fatal
rather than block-contained. Now any js-driven block degrades (warns + skips
the push) instead of taking down the whole Shiny session — not just `filter`.

`test-filter.R`: 51 pass.

Follow-up (cross-package, not here): export blockr.core `capture_conditions()`
so block-authored observers can opt into the real per-block boundary; this
`tryCatch` is the package-local stand-in.
