### PR TITLE
blockr-select: show muted label on multi-select chips

### DIFF
--- a/inst/js/blockr-select.js
+++ b/inst/js/blockr-select.js
@@ -278,7 +278,11 @@
 
         const label = document.createElement('span');
         label.className = 'blockr-select__tag-label';
-        label.textContent = val;
+        // Match the dropdown option and single-select value display: show the
+        // value in normal font with the option's label muted on the side
+        // (`.blockr-select__opt-label`). Unnamed options fall back to bare value.
+        const opt = findOpt(options, val);
+        if (opt) { fillOptContent(label, opt); } else { label.textContent = val; }
         tag.appendChild(label);
 
         const removeBtn = document.createElement('button');


### PR DESCRIPTION
## What

The multi-select chip renderer (`renderTags`) printed only the option **value**, while the dropdown options and the single-select value display already show the value in normal font with the option's **label muted alongside** (`.blockr-select__opt-label`).

This reuses `fillOptContent` so selected chips match that style. Unnamed options fall back to the bare value.

## Why

Visual consistency: selected chips now render the same way as the dropdown and single-select value display, instead of showing only the raw value.

## Change

- `inst/js/blockr-select.js`: in `renderTags`, look up the option via `findOpt` and render with `fillOptContent` (same pattern already used for the single-select value at line ~258); fall back to bare value for unnamed options.

Type-checks clean (`// @ts-check`, verified locally with `tsc`).