### PR TITLE
Implement allowEmpty in Blockr.Select single mode

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: blockr.dplyr
 Title: Interactive 'dplyr' Data Transformation Blocks
-Version: 0.2.0
+Version: 0.2.0.9000
 Authors@R:
     c(person(given = "Christoph",
              family = "Sax",

--- a/dev/test-select-allowempty.js
+++ b/dev/test-select-allowempty.js
@@ -1,0 +1,129 @@
+// Blockr.Select single-mode selection semantics, exercised in a real DOM.
+//
+// Focus: `allowEmpty` (blockr-select.md / ux-principles.md). With it, '' means
+// "nothing selected" and survives setOptions(), and a selection that is no
+// longer among the options CLEARS rather than sliding onto option 0. The
+// `default:` cases below are regression guards: allowEmpty defaults to false
+// and every pre-existing block must behave exactly as it did.
+//
+// jsdom is not a package dependency; install it ad hoc. Node 18 needs jsdom@22
+// (later majors are ESM-only and break `require`). Run from the workspace root:
+//
+//   npm i --no-save jsdom@22
+//   node blockr.dplyr/dev/test-select-allowempty.js
+const { JSDOM } = require('jsdom');
+const fs = require('fs');
+
+const path = require('path');
+const JS = path.join(__dirname, '..', 'inst', 'js');
+const dom = new JSDOM('<!doctype html><body></body>', {
+  pretendToBeVisual: true,
+  runScripts: 'dangerously'
+});
+const w = dom.window;
+const run = (f) => {
+  const el = w.document.createElement('script');
+  el.textContent = fs.readFileSync(path.join(JS, f), 'utf8');
+  w.document.body.appendChild(el);
+};
+run('blockr-core.js');
+run('blockr-select.js');
+
+let pass = 0, fail = 0;
+const ok = (label, got, want) => {
+  const good = JSON.stringify(got) === JSON.stringify(want);
+  if (good) pass++; else fail++;
+  console.log(`${good ? 'PASS ' : 'FAIL '} ${label}${good ? '' : `  got ${JSON.stringify(got)} want ${JSON.stringify(want)}`}`);
+};
+
+const mk = (config) => {
+  const el = w.document.createElement('div');
+  w.document.body.appendChild(el);
+  return w.Blockr.Select.single(el, config);
+};
+
+const A = [{ value: 'a', label: 'Arm A' }, { value: 'b', label: 'Arm B' }];
+const B = [{ value: 'c', label: 'Arm C' }, { value: 'd', label: 'Arm D' }];
+
+// ---- allowEmpty: true --------------------------------------------------
+ok('allowEmpty: no `selected` starts empty',
+  mk({ options: A, allowEmpty: true }).getValue(), '');
+
+ok('allowEmpty: explicit selected is honoured',
+  mk({ options: A, selected: 'b', allowEmpty: true }).getValue(), 'b');
+
+{
+  const s = mk({ options: A, allowEmpty: true });
+  s.setOptions(B, '');
+  ok("allowEmpty: '' survives setOptions", s.getValue(), '');
+}
+{
+  // The pharma stale-pick case: cohort changes, picked patient is gone.
+  const s = mk({ options: A, selected: 'a', allowEmpty: true });
+  s.setOptions(B, 'a');
+  ok('allowEmpty: stale selection CLEARS, no auto-pick', s.getValue(), '');
+}
+{
+  const s = mk({ options: A, selected: 'a', allowEmpty: true });
+  s.setOptions(B, 'd');
+  ok('allowEmpty: valid new selection applies', s.getValue(), 'd');
+}
+{
+  // Steppers path: options unchanged, value pushed from the server.
+  const s = mk({ options: A, allowEmpty: true });
+  s.setOptions(A, 'b');
+  ok('allowEmpty: value-only push selects', s.getValue(), 'b');
+}
+{
+  const s = mk({ options: A, selected: 'b', allowEmpty: true });
+  s.setOptions(A);
+  ok('allowEmpty: omitted `sel` keeps a still-valid selection', s.getValue(), 'b');
+}
+{
+  const s = mk({ options: A, selected: 'b', allowEmpty: true });
+  s.setOptions([]);
+  ok('allowEmpty: emptying the options clears', s.getValue(), '');
+}
+
+// ---- allowEmpty: false (default) — MUST be unchanged -------------------
+ok('default: no `selected` falls back to option 0',
+  mk({ options: A }).getValue(), 'a');
+
+ok('default: no options yields empty',
+  mk({ options: [] }).getValue(), '');
+
+ok('default: selected:"" is honoured at construct time',
+  mk({ options: A, selected: '' }).getValue(), '');
+
+{
+  const s = mk({ options: A, selected: 'b' });
+  s.setOptions(B, 'b');
+  ok('default: stale selection falls back to option 0', s.getValue(), 'c');
+}
+{
+  const s = mk({ options: A, selected: 'a' });
+  s.setOptions(B, 'd');
+  ok('default: valid new selection applies', s.getValue(), 'd');
+}
+{
+  const s = mk({ options: A, selected: 'b' });
+  s.setOptions(B);
+  ok('default: omitted `sel` resets to option 0', s.getValue(), 'c');
+}
+{
+  const s = mk({ options: A, selected: 'a' });
+  s.setOptions([]);
+  ok('default: emptying the options clears', s.getValue(), '');
+}
+
+// ---- multi mode must ignore allowEmpty ---------------------------------
+{
+  const el = w.document.createElement('div');
+  w.document.body.appendChild(el);
+  const m = w.Blockr.Select.multi(el, { options: A, selected: ['a'], allowEmpty: true });
+  m.setOptions(B, ['c']);
+  ok('multi: allowEmpty is inert', m.getValue(), ['c']);
+}
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);

--- a/inst/js/blockr-select.js
+++ b/inst/js/blockr-select.js
@@ -51,10 +51,17 @@
 
     // State
     let options = config.options || [];
+    // Single mode only: opt out of the first-option fallback so '' means
+    // "nothing selected" and survives setOptions(). Without it, any option
+    // refresh silently picks option 0 — fine for a column picker, wrong
+    // wherever an unrequested pick would change what the user is looking at.
+    const allowEmpty = mode === 'single' && config.allowEmpty === true;
     /** @type {string | string[]} string in 'single' mode, string[] in 'multi' */
     let selected = mode === 'multi'
       ? (config.selected || []).slice()
-      : (config.selected != null ? config.selected : (options.length > 0 ? optValue(options[0]) : ''));
+      : (config.selected != null
+          ? config.selected
+          : (allowEmpty || options.length === 0 ? '' : optValue(options[0])));
     const placeholder = config.placeholder || '';
     const reorderable = mode === 'multi' && config.reorderable !== false;
     const onChange = config.onChange || null;
@@ -620,6 +627,14 @@
         if (mode === 'single') {
           if (sel != null && vals.indexOf(/** @type {string} */ (sel)) >= 0) {
             selected = sel;
+          } else if (allowEmpty) {
+            // '' survives, and a selection that is no longer among the options
+            // CLEARS rather than sliding onto option 0. Omitting `sel` keeps a
+            // still-valid selection instead of resetting it.
+            selected = (sel == null &&
+                        vals.indexOf(/** @type {string} */ (selected)) >= 0)
+              ? selected
+              : '';
           } else if (options.length > 0) {
             selected = optValue(options[0]);
           } else {

--- a/inst/js/types.d.ts
+++ b/inst/js/types.d.ts
@@ -105,6 +105,12 @@ interface BlockrSelectConfigBase {
 interface BlockrSelectSingleConfig extends BlockrSelectConfigBase {
   /** Initial value (null/undefined: first option, or '' if none). */
   selected?: string | null;
+  /**
+   * Opt out of the first-option fallback: `''` means "nothing selected" and
+   * survives `setOptions()`, so the placeholder keeps showing. Use when a
+   * silent auto-pick would change results (default false).
+   */
+  allowEmpty?: boolean;
   onChange?: (value: string) => void;
 }
 
@@ -120,6 +126,7 @@ interface BlockrSelectMultiConfig extends BlockrSelectConfigBase {
 /** Internal union as consumed by createSelect (mode picks the shape). */
 interface BlockrSelectConfig extends BlockrSelectConfigBase {
   selected?: string | string[] | null;
+  allowEmpty?: boolean;
   reorderable?: boolean;
   /** `any` so both per-mode signatures are assignable under strict variance. */
   onChange?: (value: any) => void;


### PR DESCRIPTION
## Summary
- `allowEmpty` was documented in blockr.docs (design-system/components/blockr-select.md and design-system/ux-principles.md) but never implemented in blockr-select.js
- Single mode fell through to `optValue(options[0])` both at construction and on every `setOptions()`, silently auto-picking the first option for required fields that started empty
- With `allowEmpty: true`, `''` now means "nothing selected" and survives `setOptions()`; a selection no longer among the options clears rather than sliding onto option 0
- Flag defaults to `false` and multi mode ignores it, so existing blocks are unaffected

## Test plan
- `dev/test-select-allowempty.js`: 16 jsdom cases, 6 of them `default:` regression guards over untouched paths