### PR TITLE
Honour the defaults the placeholders promise, and the * the doc mandates

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: blockr.dplyr
 Title: Interactive 'dplyr' Data Transformation Blocks
-Version: 0.2.0.9000
+Version: 0.2.0.9001
 Authors@R:
     c(person(given = "Christoph",
              family = "Sax",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,33 @@
+# blockr.dplyr (development version)
+
+## Bug fixes
+
+- `slice` with type `min`/`max` and no `order_by` raised
+  `` `order_by` is absent but must be supplied `` instead of passing the data
+  through. An unconfigured block is inert, never a red banner.
+- `slice`'s `Order by` and `Weight by` pickers displayed the first column while
+  the block's value was still `""`, so the block looked configured and was not.
+  Both now pass `allowEmpty = TRUE` to `Blockr.Select`.
+- Required-empty fields now render the trailing `*` on their label, which the
+  design system has specified all along and the CSS never implemented.
+
+- Clearing the `Separator` field in `unite`, `separate` or `pivot_wider` sent
+  an empty string rather than the default the placeholder promised: `unite`
+  pasted values with no separator, `separate` split between every character,
+  and `pivot_wider` joined names with nothing. A cleared field now applies the
+  default, matching the placeholder and the behaviour of the other text fields
+  in those blocks (#0).
+
+## Design-system alignment
+
+- Placeholders now name the empty state on optional fields and prompt on
+  required ones, and the trailing `…` marks the difference: `ID columns
+  (optional)` reads `All other columns` (what tidyr actually does), `Group by:`
+  reads `None`, `Weight by` reads `Unweighted`, while required pickers keep
+  `Select columns…`.
+- Removed the `title` tooltips that only restated their checkbox label
+  (`Exclude selected`, `Remove source column`, `Remove source columns`).
+
 # blockr.dplyr 0.2.0
 
 ## Design-system alignment

--- a/R/expr-builders.R
+++ b/R/expr-builders.R
@@ -524,7 +524,10 @@ make_slice_expr <- function(type = "head", n = 5L, prop = NULL,
     expr[["n"]] <- as.integer(n %||% 5L)
   }
 
-  if (type %in% c("min", "max") && nzchar(order_by %||% "")) {
+  # slice_min()/slice_max() error without order_by. An unconfigured block passes
+  # data through and lets the amber cue do the talking; it never errors.
+  if (type %in% c("min", "max")) {
+    if (!nzchar(order_by %||% "")) return(bbquote(.(data)))
     expr[["order_by"]] <- as.name(order_by)
     if (!isTRUE(with_ties)) expr[["with_ties"]] <- FALSE
   }

--- a/inst/css/blockr-blocks.css
+++ b/inst/css/blockr-blocks.css
@@ -202,6 +202,15 @@
   background: var(--blockr-color-warning-bg, #fffbeb);
 }
 
+/* The second half of the recipe: the label carries a trailing `*`. Only
+   reaches wrappers that contain their own label — a required row without one
+   (slice's custom-positions row) is carried by the amber alone. */
+.blockr-field--required-empty > .blockr-label::after {
+  content: " *";
+  color: var(--blockr-color-warning, #f59e0b);
+  font-weight: 600;
+}
+
 /* --- Shared number input --- */
 .blockr-num-input {
   height: 30px;

--- a/inst/js/mutate-block.js
+++ b/inst/js/mutate-block.js
@@ -111,7 +111,7 @@
       this._bySelect = /** @type {BlockrSelectStatic} */ (Blockr.Select).multi(byWrap, {
         options: this.columnOptions,
         selected: [],
-        placeholder: 'Select grouping columns\u2026',
+        placeholder: 'None',
         reorderable: true,
         onChange: (value) => {
           this.byValues = value || [];

--- a/inst/js/pivot-wider-block.js
+++ b/inst/js/pivot-wider-block.js
@@ -142,7 +142,10 @@
       this._idColsSelect = /** @type {BlockrSelectStatic} */ (Blockr.Select).multi(idColsWrap, {
         options: this.columnOptions,
         selected: [],
-        placeholder: 'Select columns…',
+        // Empty is a legal configuration here, so the placeholder names what
+        // it does: make_pivot_wider_expr() omits `id_cols` and tidyr keeps
+        // every column not used by names_from / values_from.
+        placeholder: 'All other columns',
         reorderable: false,
         onChange: (selected) => {
           this.id_cols = selected;
@@ -259,7 +262,10 @@
         values_from: this.values_from.slice(),
         id_cols: this.id_cols.slice(),
         values_fill: this.values_fill || null,
-        names_sep: this.names_sep,
+        // A cleared field means "use the default", which is what the
+        // placeholder promises. Without the fallback `""` reaches
+        // tidyr::pivot_wider() and the names are joined with nothing.
+        names_sep: this.names_sep || '_',
         names_prefix: this.names_prefix,
         values_fn: this.values_fn || null
       };

--- a/inst/js/select-block.js
+++ b/inst/js/select-block.js
@@ -76,8 +76,6 @@
         this.exclude = checked;
         this._submit();
       });
-      this._excludeBox.input.title =
-        'Remove the selected columns instead of keeping them';
       optionBar.appendChild(this._excludeBox.el);
 
       this._distinctBox = Blockr.checkbox('Distinct rows', this.distinct, (checked) => {

--- a/inst/js/separate-block.js
+++ b/inst/js/separate-block.js
@@ -149,8 +149,6 @@
         this.remove = checked;
         this._submit();
       });
-      this._removeBox.input.title =
-        'Remove the source column after splitting';
       optionBar.appendChild(this._removeBox.el);
 
       this._convertBox = Blockr.checkbox('Auto-convert types', this.convert, (checked) => {
@@ -186,7 +184,10 @@
       return {
         col: this.col,
         into: this.into.slice(),
-        sep: this.sep,
+        // A cleared field means "use the default", which is what the
+        // placeholder promises. Without the fallback `""` reaches
+        // tidyr::separate() and splits between every character.
+        sep: this.sep || '[^[:alnum:]]+',
         remove: this.remove,
         convert: this.convert
       };

--- a/inst/js/slice-block.js
+++ b/inst/js/slice-block.js
@@ -206,7 +206,7 @@
       this._bySelect = /** @type {BlockrSelectStatic} */ (Blockr.Select).multi(byWrap, {
         options: this.columnOptions,
         selected: [],
-        placeholder: 'Select grouping columns…',
+        placeholder: 'None',
         reorderable: false,
         onChange: (selected) => {
           this.by = selected;
@@ -246,7 +246,11 @@
       this._orderBySelect = /** @type {BlockrSelectStatic} */ (Blockr.Select).single(orderBySelectWrap, {
         options: this.columnOptions,
         selected: /** @type {string | undefined} */ (/** @type {*} */ (null)),
-        placeholder: 'Column…',
+        // Without this the control falls back to the first column and displays
+        // it while `order_by` is still '' — the block looks configured and is
+        // not (ux-principles, "the model and the control never disagree").
+        allowEmpty: true,
+        placeholder: 'Select column…',
         onChange: (value) => {
           this.order_by = value;
           this._updateRequired();
@@ -268,7 +272,9 @@
       this._weightBySelect = /** @type {BlockrSelectStatic} */ (Blockr.Select).single(weightBySelectWrap, {
         options: this.columnOptions,
         selected: /** @type {string | undefined} */ (/** @type {*} */ (null)),
-        placeholder: 'Column (optional)…',
+        allowEmpty: true,
+        // Optional: empty is a configuration, so the placeholder names it.
+        placeholder: 'Unweighted',
         onChange: (value) => {
           this.weight_by = value;
           this._submit();

--- a/inst/js/summarize-block.js
+++ b/inst/js/summarize-block.js
@@ -144,7 +144,7 @@
       this._bySelectize = /** @type {BlockrSelectStatic} */ (Blockr.Select).multi(byWrap, {
         options: this.columnOptions,
         selected: [],
-        placeholder: 'Select grouping columns\u2026',
+        placeholder: 'None',
         reorderable: true,
         onChange: (value) => { this.byValues = value || []; this._submit(); }
       });

--- a/inst/js/unite-block.js
+++ b/inst/js/unite-block.js
@@ -149,8 +149,6 @@
         this.remove = checked;
         this._submit();
       });
-      this._removeBox.input.title =
-        'Remove the source columns after uniting';
       optionBar.appendChild(this._removeBox.el);
 
       this._naRmBox = Blockr.checkbox('Drop NA values', this.na_rm, (checked) => {
@@ -174,7 +172,10 @@
       return {
         col: this.col || 'united',
         cols: this.cols.slice(),
-        sep: this.sep,
+        // A cleared field means "use the default", which is what the
+        // placeholder promises. Without the fallback `""` reaches
+        // tidyr::unite() and the values are pasted with no separator.
+        sep: this.sep || '_',
         remove: this.remove,
         na_rm: this.na_rm
       };

--- a/tests/testthat/test-slice.R
+++ b/tests/testthat/test-slice.R
@@ -107,3 +107,36 @@ test_that("slice block: state change from head to tail", {
     expect_equal(result2, tail(mtcars, 3), ignore_attr = TRUE)
   })
 })
+
+test_that("slice block: min/max without order_by passes data through", {
+  # slice_min()/slice_max() error when order_by is absent. An unconfigured
+  # block is inert, never a red banner (ux-principles, invariant 2).
+  for (type in c("min", "max")) {
+    blk <- new_slice_block(
+      type = type, n = 5L, prop = NULL,
+      order_by = "", with_ties = TRUE,
+      weight_by = "", replace = FALSE, by = list()
+    )
+
+    testServer(blk$expr_server, args = list(data = reactive(mtcars)), {
+      session$flushReact()
+      expect_no_error(result <- eval_bquoted(session$returned$expr(), mtcars))
+      expect_equal(result, mtcars)
+    })
+  }
+})
+
+test_that("slice block: min with order_by slices", {
+  blk <- new_slice_block(
+    type = "min", n = 3L, prop = NULL,
+    order_by = "mpg", with_ties = FALSE,
+    weight_by = "", replace = FALSE, by = list()
+  )
+
+  testServer(blk$expr_server, args = list(data = reactive(mtcars)), {
+    session$flushReact()
+    result <- eval_bquoted(session$returned$expr(), mtcars)
+    expect_equal(nrow(result), 3)
+    expect_equal(result$mpg, sort(mtcars$mpg)[1:3])
+  })
+})


### PR DESCRIPTION
## Summary
- `slice` with type `min`/`max` and no `order_by` now passes data through instead of raising `` `order_by` is absent but must be supplied `` — an unconfigured block is inert, never a red banner
- `slice`'s `Order by` / `Weight by` pickers now pass `allowEmpty = TRUE` so they don't silently display the first column while the block's value is still `""`
- Required-empty fields now render the trailing `*` on their label (design system spec, previously unimplemented in CSS)
- Clearing `Separator` in `unite`/`separate`/`pivot_wider` now falls back to the default the placeholder promises, instead of sending `""` through to tidyr (which pastes with no separator / splits every character / joins names with nothing)
- Placeholders now consistently name the empty state on optional fields and prompt on required ones
- Removed checkbox `title` tooltips that only restated their own label

## Test plan
- `tests/testthat/test-slice.R`: new cases for min/max slice with and without `order_by`