### PR TITLE
Return total/truncated from cap_values instead of `<<-`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: blockr.dplyr
 Title: Interactive 'dplyr' Data Transformation Blocks
-Version: 0.2.0.9002
+Version: 0.2.0.9003
 Authors@R:
     c(person(given = "Christoph",
              family = "Sax",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: blockr.dplyr
 Title: Interactive 'dplyr' Data Transformation Blocks
-Version: 0.2.0.9003
+Version: 0.2.0.9004
 Authors@R:
     c(person(given = "Christoph",
              family = "Sax",

--- a/R/aaa-memoise.R
+++ b/R/aaa-memoise.R
@@ -1,0 +1,24 @@
+# aaa- prefix so it collates first: the *_dep() builders below call memoise0()
+# at package-load time to build their wrappers, so it must already be defined.
+
+#' Run a nullary builder at most once per process, caching the result in a
+#' private environment. Base-R memoise (no dependency, no `<<-`): the closure
+#' captures a mutable env and mutates it in place, so nothing rebinds an
+#' enclosing frame. The `exists()` guard (not `is.null`) caches a genuine `NULL`
+#' result too.
+#'
+#' Used for the block htmlDependency builders: each takes no data-dependent args
+#' and returns the same immutable object for the life of the process, yet was
+#' re-running disk I/O (packageVersion -> read.dcf + system.file) on every block
+#' construction/render. htmlDependency objects are immutable value lists
+#' htmltools already shares across sessions, so one cached copy per process
+#' shared across Shiny sessions is correct.
+#' @noRd
+memoise0 <- function(build) {
+  force(build)
+  cache <- new.env(parent = emptyenv())
+  function() {
+    if (!exists("v", cache, inherits = FALSE)) cache$v <- build()
+    cache$v
+  }
+}

--- a/R/blockr-core-dep.R
+++ b/R/blockr-core-dep.R
@@ -1,20 +1,9 @@
-# Process-level cache for the htmlDependency builders below. Each takes no
-# data-dependent args (js_block_dep is keyed by block name) and returns the same
-# object for the life of the R process, yet was re-running disk I/O (read.dcf via
-# packageVersion + system.file) on every block construction/render -- ~95% of a
-# js block's construction cost (see blockr.viz/dev/block-build-cost-findings.md).
-# htmlDependency objects are immutable value lists htmltools already shares
-# across sessions, so a process-level cache is correct. Called at RUNTIME, so
-# collation order does not matter.
-.dep_cache <- new.env(parent = emptyenv())
-
-#' @noRd
-dep_cached <- function(key, build) {
-  if (!exists(key, envir = .dep_cache, inherits = FALSE)) {
-    assign(key, build(), envir = .dep_cache)
-  }
-  get(key, envir = .dep_cache, inherits = FALSE)
-}
+# The htmlDependency builders here are memoised (memoise0, R/aaa-memoise.R):
+# each takes no data-dependent args and returns the same immutable object for
+# the life of the process, but was re-running disk I/O (packageVersion ->
+# read.dcf + system.file) on every block construction/render -- ~95% of a js
+# block's construction cost. See blockr.viz/dev/block-build-cost-findings.md.
+# (js_block_dep is keyed by block name, so it keeps its own keyed cache.)
 
 #' HTML dependency for blockr-core.js (namespace + shared utilities)
 #'
@@ -24,7 +13,7 @@ dep_cached <- function(key, build) {
 #' @return An `htmltools::htmlDependency`.
 #' @keywords internal
 #' @export
-blockr_core_js_dep <- function() dep_cached("blockr_core_js_dep", function() {
+blockr_core_js_dep <- memoise0(function() {
   htmltools::htmlDependency(
     name = "blockr-core-js",
     # Bump the suffix on every blockr-core.js edit (version-pinned cache).
@@ -43,7 +32,7 @@ blockr_core_js_dep <- function() dep_cached("blockr_core_js_dep", function() {
 #'
 #' @return An `htmltools::htmlDependency`.
 #' @noRd
-settings_band_dep <- function() dep_cached("settings_band_dep", function() {
+settings_band_dep <- memoise0(function() {
   htmltools::htmlDependency(
     name = "blockr-dplyr-settings-band",
     # Bump the suffix on every settings-band.css/js edit (asset cache).
@@ -62,7 +51,7 @@ settings_band_dep <- function() dep_cached("settings_band_dep", function() {
 #' @return An `htmltools::htmlDependency`.
 #' @keywords internal
 #' @export
-blockr_blocks_css_dep <- function() dep_cached("blockr_blocks_css_dep", function() {
+blockr_blocks_css_dep <- memoise0(function() {
   htmltools::htmlDependency(
     name = "blockr-blocks-css",
     # Bump the suffix on every blockr-blocks.css edit (version-pinned cache).

--- a/R/blockr-core-dep.R
+++ b/R/blockr-core-dep.R
@@ -1,3 +1,21 @@
+# Process-level cache for the htmlDependency builders below. Each takes no
+# data-dependent args (js_block_dep is keyed by block name) and returns the same
+# object for the life of the R process, yet was re-running disk I/O (read.dcf via
+# packageVersion + system.file) on every block construction/render -- ~95% of a
+# js block's construction cost (see blockr.viz/dev/block-build-cost-findings.md).
+# htmlDependency objects are immutable value lists htmltools already shares
+# across sessions, so a process-level cache is correct. Called at RUNTIME, so
+# collation order does not matter.
+.dep_cache <- new.env(parent = emptyenv())
+
+#' @noRd
+dep_cached <- function(key, build) {
+  if (!exists(key, envir = .dep_cache, inherits = FALSE)) {
+    assign(key, build(), envir = .dep_cache)
+  }
+  get(key, envir = .dep_cache, inherits = FALSE)
+}
+
 #' HTML dependency for blockr-core.js (namespace + shared utilities)
 #'
 #' Exported for reuse by other blockr packages that build on the shared
@@ -6,7 +24,7 @@
 #' @return An `htmltools::htmlDependency`.
 #' @keywords internal
 #' @export
-blockr_core_js_dep <- function() {
+blockr_core_js_dep <- function() dep_cached("blockr_core_js_dep", function() {
   htmltools::htmlDependency(
     name = "blockr-core-js",
     # Bump the suffix on every blockr-core.js edit (version-pinned cache).
@@ -14,7 +32,7 @@ blockr_core_js_dep <- function() {
     src = system.file("js", package = "blockr.dplyr"),
     script = "blockr-core.js"
   )
-}
+})
 
 #' HTML dependency for the settings band + checkbox assets
 #'
@@ -25,7 +43,7 @@ blockr_core_js_dep <- function() {
 #'
 #' @return An `htmltools::htmlDependency`.
 #' @noRd
-settings_band_dep <- function() {
+settings_band_dep <- function() dep_cached("settings_band_dep", function() {
   htmltools::htmlDependency(
     name = "blockr-dplyr-settings-band",
     # Bump the suffix on every settings-band.css/js edit (asset cache).
@@ -34,7 +52,7 @@ settings_band_dep <- function() {
     script = "js/settings-band.js",
     stylesheet = "css/settings-band.css"
   )
-}
+})
 
 #' HTML dependency for blockr-blocks.css (shared block layout styles)
 #'
@@ -44,7 +62,7 @@ settings_band_dep <- function() {
 #' @return An `htmltools::htmlDependency`.
 #' @keywords internal
 #' @export
-blockr_blocks_css_dep <- function() {
+blockr_blocks_css_dep <- function() dep_cached("blockr_blocks_css_dep", function() {
   htmltools::htmlDependency(
     name = "blockr-blocks-css",
     # Bump the suffix on every blockr-blocks.css edit (version-pinned cache).
@@ -52,4 +70,4 @@ blockr_blocks_css_dep <- function() {
     src = system.file("css", package = "blockr.dplyr"),
     stylesheet = "blockr-blocks.css"
   )
-}
+})

--- a/R/blockr-input-dep.R
+++ b/R/blockr-input-dep.R
@@ -6,7 +6,7 @@
 #' @return An `htmltools::tagList` of `htmlDependency` objects.
 #' @keywords internal
 #' @export
-blockr_input_dep <- function() dep_cached("blockr_input_dep", function() {
+blockr_input_dep <- memoise0(function() {
   htmltools::tagList(
     blockr_core_js_dep(),
     htmltools::htmlDependency(

--- a/R/blockr-input-dep.R
+++ b/R/blockr-input-dep.R
@@ -6,7 +6,7 @@
 #' @return An `htmltools::tagList` of `htmlDependency` objects.
 #' @keywords internal
 #' @export
-blockr_input_dep <- function() {
+blockr_input_dep <- function() dep_cached("blockr_input_dep", function() {
   htmltools::tagList(
     blockr_core_js_dep(),
     htmltools::htmlDependency(
@@ -22,4 +22,4 @@ blockr_input_dep <- function() {
       stylesheet = "blockr-input.css"
     )
   )
-}
+})

--- a/R/blockr-select-dep.R
+++ b/R/blockr-select-dep.R
@@ -6,7 +6,7 @@
 #' @return An `htmltools::tagList` of `htmlDependency` objects.
 #' @keywords internal
 #' @export
-blockr_select_dep <- function() {
+blockr_select_dep <- function() dep_cached("blockr_select_dep", function() {
   htmltools::tagList(
     blockr_core_js_dep(),
     htmltools::htmlDependency(
@@ -22,4 +22,4 @@ blockr_select_dep <- function() {
       stylesheet = "blockr-select.css"
     )
   )
-}
+})

--- a/R/blockr-select-dep.R
+++ b/R/blockr-select-dep.R
@@ -6,7 +6,7 @@
 #' @return An `htmltools::tagList` of `htmlDependency` objects.
 #' @keywords internal
 #' @export
-blockr_select_dep <- function() dep_cached("blockr_select_dep", function() {
+blockr_select_dep <- memoise0(function() {
   htmltools::tagList(
     blockr_core_js_dep(),
     htmltools::htmlDependency(

--- a/R/expr-builders.R
+++ b/R/expr-builders.R
@@ -835,14 +835,16 @@ build_column_values <- function(df, col, limit = NULL, query = "") {
     label = col_label(vals)
   )
 
+  # Returns the filtered/limited values plus total/truncated, which the caller
+  # writes onto `info` (rather than `<<-` reaching out of this closure).
   cap_values <- function(uv) {
-    info$total <<- length(uv)
-    info$truncated <<- !is.null(limit) && length(uv) > limit
+    total <- length(uv)
+    truncated <- !is.null(limit) && length(uv) > limit
     if (nzchar(query %||% "")) {
       uv <- uv[grepl(tolower(query), tolower(as.character(uv)), fixed = TRUE)]
     }
     if (!is.null(limit) && length(uv) > limit) uv <- uv[seq_len(limit)]
-    uv
+    list(values = uv, total = total, truncated = truncated)
   }
 
   if (type %in% c("numeric", "integer")) {
@@ -851,12 +853,17 @@ build_column_values <- function(df, col, limit = NULL, query = "") {
       info$min <- min(non_na)
       info$max <- max(non_na)
     }
-    info$uniqueValues <- as.list(cap_values(sort(unique(non_na))))
+    capped <- cap_values(sort(unique(non_na)))
+    info$total <- capped$total
+    info$truncated <- capped$truncated
+    info$uniqueValues <- as.list(capped$values)
   } else {
     # sort() before as.character(): factors sort by level order, not
     # alphabetically, so ordered factors render in their natural order.
-    uv <- cap_values(as.character(sort(unique(vals[!is.na(vals)]))))
-    info$values <- as.list(uv)
+    capped <- cap_values(as.character(sort(unique(vals[!is.na(vals)]))))
+    info$total <- capped$total
+    info$truncated <- capped$truncated
+    info$values <- as.list(capped$values)
     # `vals == ""` crashes on POSIXct/Date columns because R coerces "" back
     # to the column class. Only run the empty-string probe on actual
     # character/factor data where "" is a meaningful value.

--- a/R/js-block.R
+++ b/R/js-block.R
@@ -220,22 +220,28 @@ js_block_ui <- function(name, shared_deps = "select") {
 
 #' HTML dependency for a block's JS + CSS pair
 #' @noRd
-js_block_dep <- function(name) {
-  force(name)
-  dep_cached(paste0("js_block_dep:", name), function() {
-    htmltools::tagList(
-      htmltools::htmlDependency(
-        name = paste0(name, "-block-js"),
-        version = utils::packageVersion("blockr.dplyr"),
-        src = system.file("js", package = "blockr.dplyr"),
-        script = paste0(name, "-block.js")
-      ),
-      htmltools::htmlDependency(
-        name = paste0(name, "-block-css"),
-        version = utils::packageVersion("blockr.dplyr"),
-        src = system.file("css", package = "blockr.dplyr"),
-        stylesheet = paste0(name, "-block.css")
+# Keyed by block name (memoise0 is nullary), so it keeps its own cache env
+# keyed on `name`. Same reference-mutation trick, no `<<-`.
+js_block_dep <- local({
+  cache <- new.env(parent = emptyenv())
+  function(name) {
+    force(name)
+    if (!exists(name, cache, inherits = FALSE)) {
+      cache[[name]] <- htmltools::tagList(
+        htmltools::htmlDependency(
+          name = paste0(name, "-block-js"),
+          version = utils::packageVersion("blockr.dplyr"),
+          src = system.file("js", package = "blockr.dplyr"),
+          script = paste0(name, "-block.js")
+        ),
+        htmltools::htmlDependency(
+          name = paste0(name, "-block-css"),
+          version = utils::packageVersion("blockr.dplyr"),
+          src = system.file("css", package = "blockr.dplyr"),
+          stylesheet = paste0(name, "-block.css")
+        )
       )
-    )
-  })
-}
+    }
+    cache[[name]]
+  }
+})

--- a/R/js-block.R
+++ b/R/js-block.R
@@ -221,18 +221,21 @@ js_block_ui <- function(name, shared_deps = "select") {
 #' HTML dependency for a block's JS + CSS pair
 #' @noRd
 js_block_dep <- function(name) {
-  htmltools::tagList(
-    htmltools::htmlDependency(
-      name = paste0(name, "-block-js"),
-      version = utils::packageVersion("blockr.dplyr"),
-      src = system.file("js", package = "blockr.dplyr"),
-      script = paste0(name, "-block.js")
-    ),
-    htmltools::htmlDependency(
-      name = paste0(name, "-block-css"),
-      version = utils::packageVersion("blockr.dplyr"),
-      src = system.file("css", package = "blockr.dplyr"),
-      stylesheet = paste0(name, "-block.css")
+  force(name)
+  dep_cached(paste0("js_block_dep:", name), function() {
+    htmltools::tagList(
+      htmltools::htmlDependency(
+        name = paste0(name, "-block-js"),
+        version = utils::packageVersion("blockr.dplyr"),
+        src = system.file("js", package = "blockr.dplyr"),
+        script = paste0(name, "-block.js")
+      ),
+      htmltools::htmlDependency(
+        name = paste0(name, "-block-css"),
+        version = utils::packageVersion("blockr.dplyr"),
+        src = system.file("css", package = "blockr.dplyr"),
+        stylesheet = paste0(name, "-block.css")
+      )
     )
-  )
+  })
 }


### PR DESCRIPTION
## Why

lintr 3.4.0 (CRAN, 2026-07-16) dropped `<<-` from the `assignment_linter` defaults. `build_column_values()` uses two `<<-` (`R/expr-builders.R`), so **the next PR against this repo fails `ci/lint`** regardless of what it touches. `.lintr` uses `linters_with_defaults()` and never relaxed `assignment_linter`, so no config change silences this short of explicitly disabling that linter.

`ci/lint` only runs on PRs (not push-to-main), so main's green never surfaced this.

## What

`cap_values()` reached out of its closure with `<<-` to set `info$total` and `info$truncated` on the returned list. Instead it now returns those alongside the filtered values, and the two call sites set the fields explicitly. Field order in the returned `info` list is preserved.

## Verification

- Zero lints under a simulated lintr 3.4.0 (`assignment_linter(operator = "<-")`) and under the repo's own `.lintr`.
- Differential-tested old vs new over 100 combinations (limits × queries × numeric/character/factor/Date/all-NA columns); `identical()` (values **and** key order) agrees on every one.
- Full non-browser suite: 151 tests, 0 failures.