### PR TITLE
Stop multi-select wrapping to a spurious second row; fix DAG panel id in dock preview

### DIFF
--- a/dev/preview-design-system-dock.R
+++ b/dev/preview-design-system-dock.R
@@ -103,10 +103,10 @@ serve(
     # Current dock API: named PLAIN list of `grids =` (the old `layouts =` is
     # swallowed by ... and silently ignored). Views are derived from the
     # grids. A grid child is either a bare panel id or panels(...) for a
-    # tabbed group; "dag_extension" is the DAG panel's extension_id().
+    # tabbed group; "dag" is the DAG panel's extension_id().
     # View names must be safe identifiers (letters, digits, . - _).
     grids = list(
-      Pipeline = dock_grid("dag_extension"),
+      Pipeline = dock_grid("dag"),
       `Data-IO` = dock_grid(
         panels("data", "data2"),
         panels("read", "write", "download")

--- a/inst/css/blockr-select.css
+++ b/inst/css/blockr-select.css
@@ -111,6 +111,24 @@
   position: absolute;
 }
 
+/* In multi mode when closed, take the search input out of flow as well.
+   Left in flow it holds a trailing flex slot (min-width) plus one `gap`
+   gutter, so once the tags leave less than that free, the empty input alone
+   wraps to a second row and inflates the control even though the tags fit on
+   one. Zeroing its width is not enough — the gutter still counts — hence
+   position: absolute, matching the single-mode rule above.
+   Gated on a tag existing: while nothing is selected this input is the ONLY
+   element that renders the placeholder (multi mode builds no
+   `.blockr-select__value`), so collapsing it when empty blanks the control. */
+.blockr-select--multi:not(.blockr-select--open)
+  .blockr-select__tags:has(.blockr-select__tag) .blockr-select__search {
+  position: absolute;
+  width: 0;
+  min-width: 0;
+  padding: 0;
+  opacity: 0;
+}
+
 /* --- Tags container (multi mode) --- */
 .blockr-select__tags {
   display: flex;


### PR DESCRIPTION
Two independent fixes that were sitting on a local `main` and had never been through CI.

## Multi-select wrapped to a spurious second row

`inst/css/blockr-select.css`

In multi mode the search input stayed an **in-flow flex item** of the tags row while the dropdown was closed, holding a `min-width` slot plus one `gap` gutter. Once the tags left less than that free, the empty input alone wrapped to a second line and inflated the control — even though the tags themselves fit on one row.

Take it out of flow when closed, matching the single-mode rule directly above it. Zeroing the width is not sufficient on its own: flex line-breaking still counts the gutter, which leaves a narrow band of container widths that keep wrapping.

Gated on a tag existing. While nothing is selected, this input is the *only* element that renders the placeholder — multi mode builds no `.blockr-select__value` and no chevron — so collapsing it unconditionally would turn every empty multi-select into a blank box.

## DAG panel id in the design-system dock preview

`dev/preview-design-system-dock.R`

`dock_grid("dag_extension")` aborted at startup with `Layout references unknown panel dag_extension`. Extensions are keyed by mount name now, not by class, so the panel registers as `"dag"`. Bare ids resolve through dock's `id_map`, so `dock_grid("dag")` is the fix (the explicit `ext("dag")` form would work equally).

Dev-only file — `^dev$` is `.Rbuildignore`d, so this is outside the built package.

## Verification

Run locally against this branch:

- `npx -y -p typescript@~6.0.0 tsc` — clean
- `lintr::lint_package()` — 0 lints
- `R CMD check --as-cran` — see below
- `testthat::test_local()` — see below

Worth noting that blockr.ci runs the `check` matrix on **push only** and lint/smoke/coverage/docs on **PR only**, so a green PR here does not exercise `R CMD check`. That is why it is verified locally too.