### PR TITLE
Re-send block state on bind so deferred dock panels are not blank

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: blockr.dplyr
 Title: Interactive 'dplyr' Data Transformation Blocks
-Version: 0.2.0.9004
+Version: 0.2.0.9005
 Authors@R:
     c(person(given = "Christoph",
              family = "Sax",

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,17 @@
 
 ## Bug fixes
 
+- Every block came up **blank** — one empty row, no column choices — when its
+  dock panel was not on the startup view, while its expression and everything
+  downstream stayed correct. The block's server runs at boot (blockr.core
+  builds it whenever a visible block downstream needs it) and pushes its state
+  and columns before the panel, and with it this package's JavaScript, has been
+  delivered; Shiny drops custom messages that have no handler yet, and the
+  replay queue in `blockr-core.js` cannot catch a message dropped before its
+  own script loaded. The binding now announces itself on bind when nothing was
+  queued for it, and R re-sends state, columns, and `summarize`'s function
+  list. Affected all 13 blocks. The core-level fix this stands in for is
+  BristolMyersSquibb/blockr.core#317.
 - `slice` with type `min`/`max` and no `order_by` raised
   `` `order_by` is absent but must be supplied `` instead of passing the data
   through. An unconfigured block is inert, never a red banner.

--- a/R/join_block.R
+++ b/R/join_block.R
@@ -47,17 +47,25 @@ new_join_block <- function(
       moduleServer(id, function(input, output, session) {
         ns <- session$ns
 
-        # Send column summary (name + label + type) when either input changes
-        observeEvent(list(x(), y()), {
-          session$sendCustomMessage(
-            "join-columns",
-            list(
-              id = ns("join_input"),
-              xColumns = build_column_picker_meta(x()),
-              yColumns = build_column_picker_meta(y())
-            )
+        send_columns <- function() {
+          tryCatch(
+            session$sendCustomMessage(
+              "join-columns",
+              list(
+                id = ns("join_input"),
+                xColumns = build_column_picker_meta(x()),
+                yColumns = build_column_picker_meta(y())
+              )
+            ),
+            error = function(e) NULL
           )
-        })
+        }
+
+        # Send column summary (name + label + type) when either input changes
+        observeEvent(list(x(), y()), send_columns())
+        # ...and when a client announces itself, which is how a block on a
+        # deferred dock panel gets the push that was dropped at boot.
+        observeEvent(input[[js_block_ready_name("join_input")]], send_columns())
 
         sync <- js_block_state(input, session, "join", "join_input", state)
 

--- a/R/js-block.R
+++ b/R/js-block.R
@@ -65,12 +65,24 @@ new_js_transform_block <- function(class,
         ns <- session$ns
 
         if (!is.null(columns_meta)) {
-          observeEvent(data(), {
-            session$sendCustomMessage(
-              paste0(name, "-columns"),
-              list(id = ns(input_name), columns = columns_meta(data()))
+          send_columns <- function() {
+            # `data()` throws while an upstream block is unset or erroring;
+            # the next `data()` change re-sends, so swallow it here rather
+            # than take down the announce observer.
+            tryCatch(
+              session$sendCustomMessage(
+                paste0(name, "-columns"),
+                list(id = ns(input_name), columns = columns_meta(data()))
+              ),
+              error = function(e) NULL
             )
-          })
+          }
+
+          observeEvent(data(), send_columns())
+          # Deferred panel: this push was dropped at boot (see js_block_state).
+          # Without it the column pickers stay EMPTY and the block cannot be
+          # configured at all, restored state or not.
+          observeEvent(input[[js_block_ready_name(input_name)]], send_columns())
         }
 
         if (!is.null(setup)) {
@@ -104,6 +116,18 @@ new_js_transform_block <- function(class,
 #' @noRd
 js_block_input_name <- function(name) {
   paste0(gsub("-", "_", name, fixed = TRUE), "_input")
+}
+
+#' Input id the client announces itself on
+#'
+#' `Blockr.registerBlock()`'s binding `initialize()` sets this input when it
+#' binds with nothing queued for it -- see [js_block_state()] for why that is
+#' the signal that a push was dropped. Every message a block sends *once* (at
+#' module start, or on a `data()` change that will not repeat) must also be
+#' sent from an `observeEvent()` on this input.
+#' @noRd
+js_block_ready_name <- function(input_name) {
+  paste0(input_name, "_ready")
 }
 
 #' Wire the bidirectional JS <-> R state sync over per-field reactiveVals
@@ -153,6 +177,30 @@ js_block_state <- function(input, session, name, input_name, state,
     for (f in fields) r_fields[[f]](blob[[f]])
   })
 
+  # This runs OUTSIDE blockr.core's per-block error boundary (which only wraps
+  # expr eval / data / render), so a throw in `normalize_state()` or
+  # serialization is session-fatal rather than contained to the block. No
+  # block's state sync may ever take down the whole session -- contain it and
+  # warn so the block degrades instead.
+  send_state <- function() {
+    tryCatch(
+      session$sendCustomMessage(
+        paste0(name, "-block-update"),
+        list(
+          id = session$ns(input_name),
+          state = normalize_state(isolate(r_state()))
+        )
+      ),
+      error = function(e) {
+        warning(
+          sprintf("blockr.dplyr: could not sync '%s' state to JS: %s",
+                  name, conditionMessage(e)),
+          call. = FALSE
+        )
+      }
+    )
+  }
+
   # R -> JS: push the recombined blob whenever any field changes.
   #
   # Sent as a custom message (not `sendInputMessage`) on purpose: the block's
@@ -166,29 +214,21 @@ js_block_state <- function(input, session, name, input_name, state,
     if (self_write$active) {
       self_write$active <- FALSE
     } else {
-      # This observer runs OUTSIDE blockr.core's per-block error boundary
-      # (which only wraps expr eval / data / render), so a throw in
-      # `normalize_state()` or serialization is session-fatal rather than
-      # contained to the block. No block's state sync may ever take down the
-      # whole session -- contain it and warn so the block degrades instead.
-      tryCatch(
-        session$sendCustomMessage(
-          paste0(name, "-block-update"),
-          list(
-            id = session$ns(input_name),
-            state = normalize_state(r_state())
-          )
-        ),
-        error = function(e) {
-          warning(
-            sprintf("blockr.dplyr: could not sync '%s' state to JS: %s",
-                    name, conditionMessage(e)),
-            call. = FALSE
-          )
-        }
-      )
+      send_state()
     }
   })
+
+  # ...except when the block sits on a dock panel that is not on the startup
+  # view. The block's server still runs at boot (blockr.core constructs it
+  # whenever a visible block downstream needs it), but its JS ships as an
+  # htmlDependency on the block's `ui()`, so it is delivered WITH the panel, on
+  # first visit. Shiny drops a custom message with no registered handler, and
+  # the queue above cannot catch a message dropped before its own script
+  # loaded. The client therefore announces itself on bind when nothing was
+  # queued for it, and we re-send. Duplicates are harmless: `setState()`
+  # rebuilds from a full snapshot and never fires the submit callback.
+  # See blockr.core#317 for the core-level fix this stands in for.
+  observeEvent(input[[js_block_ready_name(input_name)]], send_state())
 
   list(fields = r_fields, state = r_state)
 }

--- a/R/summarize_block.R
+++ b/R/summarize_block.R
@@ -130,10 +130,18 @@ new_summarize_block <- function(
       func_info <- lapply(names(all_funcs), function(label) {
         list(value = unname(all_funcs[[label]]), label = label)
       })
-      session$sendCustomMessage(
-        "summarize-functions",
-        list(id = ns(input_name), functions = func_info)
-      )
+      send_funcs <- function() {
+        session$sendCustomMessage(
+          "summarize-functions",
+          list(id = ns(input_name), functions = func_info)
+        )
+      }
+
+      send_funcs()
+      # Sent once, so a deferred dock panel drops it for good and the block
+      # silently falls back to the JS DEFAULT_SUMMARY_FUNCS -- any function
+      # added through `blockr.dplyr.summary_functions` would go missing.
+      observeEvent(input[[js_block_ready_name(input_name)]], send_funcs())
     },
     shared_deps = c("select", "input"),
     ...

--- a/inst/js/blockr-core.js
+++ b/inst/js/blockr-core.js
@@ -103,9 +103,10 @@ Blockr._enqueue = (id, channel, fn) => {
 };
 Blockr._replayPending = (el) => {
   const queue = Blockr._pending.get(el.id);
-  if (!queue) return;
+  if (!queue) return false;
   Blockr._pending.delete(el.id);
   for (const fn of queue.values()) fn(el._block);
+  return true;
 };
 
 /**
@@ -151,7 +152,19 @@ Blockr.registerBlock = ({ name, Block, messages = {} }) => {
     /** @param {BlockrBlockHost} el */
     initialize: (el) => {
       if (!el._block) el._block = new Block(el);
-      Blockr._replayPending(el);
+      // Anything R sent before this element bound was parked by _enqueue.
+      const replayed = Blockr._replayPending(el);
+      // Nothing parked means one of two things: a genuinely fresh block, or a
+      // block whose state and columns were pushed before THIS script existed
+      // -- the deferred dock panel case, where the block's JS is delivered
+      // with its panel on first visit and Shiny drops custom messages that
+      // have no handler yet. No client-side queue can catch a message dropped
+      // before the queue itself loaded, so announce instead and let R re-send
+      // (js-block.R, `js_block_ready_name()`). The extra round trip is cheap
+      // and idempotent when the block really is fresh.
+      if (!replayed) {
+        Shiny.setInputValue(`${el.id}_ready`, Date.now(), { priority: 'event' });
+      }
     }
   });
   Shiny.inputBindings.register(binding, `blockr.${name}`);

--- a/inst/js/types.d.ts
+++ b/inst/js/types.d.ts
@@ -265,7 +265,8 @@ interface BlockrNamespace {
   _docClick: Set<{ el: Element; cb: (e: MouseEvent) => void }>;
   _pending: Map<string, BlockrPendingQueue>;
   _enqueue(id: string, channel: string, fn: (block: BlockrBlock | undefined) => void): void;
-  _replayPending(el: BlockrBlockHost): void;
+  /** True if anything was parked for `el` and has now been replayed. */
+  _replayPending(el: BlockrBlockHost): boolean;
   /** Shared components (blockr-select.js / blockr-input.js) */
   Select?: BlockrSelectStatic;
   Input?: BlockrInputStatic;

--- a/tests/testthat/test-ready-handshake.R
+++ b/tests/testthat/test-ready-handshake.R
@@ -1,0 +1,96 @@
+# A block on a dock panel that is not on the startup view has its server run
+# at boot but its JavaScript delivered later, with the panel. The boot pushes
+# are dropped (Shiny discards custom messages with no handler), so the client
+# announces itself on bind and R re-sends. See blockr.core#317.
+
+# Capture custom messages. Assigning into `session$rootScope()$...` errors on
+# the proxy session, so the root MockShinySession has to be bound first.
+capture_messages <- function(session) {
+  sent <- new.env(parent = emptyenv())
+  sent$msgs <- list()
+  root <- session$rootScope()
+  root$sendCustomMessage <- function(type, message) {
+    sent$msgs <- c(sent$msgs, list(list(type = type, message = message)))
+    invisible(NULL)
+  }
+  sent
+}
+
+types_of <- function(sent) vapply(sent$msgs, `[[`, character(1L), "type")
+
+test_that("a client announcing itself gets the mutate state re-sent", {
+  blk <- new_mutate_block(
+    mutations = list(list(name = "kpl", expr = "mpg * 0.425144")),
+    by = list("cyl")
+  )
+
+  testServer(blk$expr_server, args = list(data = reactive(mtcars)), {
+    session$flushReact()
+    sent <- capture_messages(session)
+
+    session$setInputs(mutate_input_ready = 1)
+    session$flushReact()
+
+    expect_setequal(types_of(sent), c("mutate-block-update", "mutate-columns"))
+
+    state <- sent$msgs[[which(types_of(sent) == "mutate-block-update")]]$message
+    expect_equal(state$state$mutations[[1L]]$name, "kpl")
+    expect_equal(state$state$by, list("cyl"))
+
+    cols <- sent$msgs[[which(types_of(sent) == "mutate-columns")]]$message
+    expect_true(length(cols$columns) > 0L)
+  })
+})
+
+test_that("the announce re-sends summarize's state, columns and functions", {
+  blk <- new_summarize_block(
+    summaries = list(
+      list(type = "simple", name = "avg_mpg", func = "mean", col = "mpg")
+    ),
+    by = list("cyl")
+  )
+
+  testServer(blk$expr_server, args = list(data = reactive(mtcars)), {
+    session$flushReact()
+    sent <- capture_messages(session)
+
+    session$setInputs(summarize_input_ready = 1)
+    session$flushReact()
+
+    expect_setequal(
+      types_of(sent),
+      c("summarize-block-update", "summarize-columns", "summarize-functions")
+    )
+
+    state <- sent$msgs[[
+      which(types_of(sent) == "summarize-block-update")
+    ]]$message
+    expect_equal(state$state$summaries[[1L]]$name, "avg_mpg")
+  })
+})
+
+test_that("the announce re-sends state while the upstream is still unset", {
+  blk <- new_filter_block(
+    conditions = list(list(type = "expr", expr = "mpg > 20"))
+  )
+
+  testServer(
+    blk$expr_server,
+    args = list(data = reactive(req(FALSE))),
+    {
+      session$flushReact()
+      sent <- capture_messages(session)
+
+      session$setInputs(filter_input_ready = 1)
+      session$flushReact()
+
+      # No columns to send, but the state must still get through: the state
+      # push does not touch `data()`, so an unset upstream cannot leave the
+      # block blank.
+      expect_equal(types_of(sent), "filter-block-update")
+
+      state <- sent$msgs[[1L]]$message
+      expect_equal(state$state$conditions[[1L]]$expr, "mpg > 20")
+    }
+  )
+})


### PR DESCRIPTION
Blocks whose dock panel is not on the startup view came up blank: empty column
pickers, no restored state, summarize's function list missing. The expression and
everything downstream were correct, so the board looked half-alive.

blockr.core builds a server for such a block at boot (any visible downstream block
forces it), and that server pushes state and column metadata at module start. The
block's JavaScript, however, ships as an htmlDependency on `ui()` — it arrives with
the panel, on first visit. Shiny drops custom messages with no registered handler,
and the replay queue in `blockr-core.js` cannot catch a message dropped before its
own script loaded. All 13 blocks sync through `js_block_state()`, so all 13 were hit.

The binding now announces `<id>_ready` from `initialize()` when nothing was queued
for it, and R answers by re-sending. "Nothing queued" means either a fresh block or
a dropped push and the client cannot tell them apart — but a duplicate is harmless:
`setState()` rebuilds from a full snapshot and never fires the submit callback, so
no grace timer is needed.

The DESCRIPTION bump is load-bearing: the htmlDependency version is what busts the
browser cache.

Reproducer, before/after screenshots and the per-message breakdown are in
`_scratch/handover/dplyr-mutate-summarize-lazy/`. The core-level fix this stands in
for is BristolMyersSquibb/blockr.core#317, which covers the blocks with no
JavaScript to announce from (`merge_block`, `scatter_block`, blockr.dm's plain
`updateSelect*` blocks).
