### PR TITLE
Let a block keep its own column across a restore

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -12,3 +12,5 @@
 ^Meta$
 ^cran-comments\.md$
 ^tsconfig\.json$
+^node_modules$
+^package(-lock)?\.json$

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ docs/
 /doc/
 /Meta/
 vignettes/*.html
+node_modules/

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: blockr.dplyr
 Title: Interactive 'dplyr' Data Transformation Blocks
-Version: 0.2.0.9005
+Version: 0.2.0.9006
 Authors@R:
     c(person(given = "Christoph",
              family = "Sax",

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,40 @@
 
 ## Bug fixes
 
+- **Restored blocks came back pointing at the wrong columns**, or at none.
+  A block read its column back out of the `Blockr.Select` widget after
+  refreshing the widget's options, and stored whatever the widget said. A
+  column picker has no `allowEmpty`, so an option list that does not carry the
+  block's column slides the widget onto the first one — and during a restore
+  that list arrives routinely, because an upstream that has not restored yet
+  still reports the old frame's columns. The authored column was gone before
+  the real one arrived, and nothing brought it back: `setState()` rebuilds from
+  R's message, which does not repeat. Multi-column pickers lost their columns
+  outright, since `setOptions()` filters the selection against the new list.
+  Every block with a column picker was affected: `rename` renamed the wrong
+  column, `filter` kept its values while re-pointing at another column,
+  `join` joined on the wrong keys, `select`, `unite`, `pivot_longer`,
+  `pivot_wider`, `slice` and `summarize` came back empty, and `arrange` and
+  `separate` collapsed onto the first column. A block now keeps its own
+  column: one the board restored or the user picked survives a list that does
+  not offer it and lands back on its option when the real columns arrive,
+  while one the select auto-picked still follows the data.
+- Following from that, a column picker no longer drops a deliberate column
+  just because the frame in front of it does not carry one by that name. This
+  is what makes a restore survive an upstream that is still settling, and it
+  cuts the other way too: when an upstream really has removed the column, the
+  block holds on to it and fails loudly instead of quietly transforming a
+  different one. Only a column the select auto-picked still follows the data.
+- `summarize` and `join` auto-submit once they know their columns, and
+  `summarize` and `mutate` did so again from `setState()`. On a restore that
+  wrote the client's reading of the block over the state R had just sent it —
+  `mutate`'s fired before the group-by had been restored, so a restored
+  `mutate` lost its `.by` for good. These now speak only when they have
+  something to say that R did not already tell them.
+- R pushes a block's state before its columns, so a block that auto-submits on
+  columns can no longer answer with a fabricated state before its restore has
+  arrived.
+
 - Every block came up **blank** — one empty row, no column choices — when its
   dock panel was not on the startup view, while its expression and everything
   downstream stayed correct. The block's server runs at boot (blockr.core

--- a/R/join_block.R
+++ b/R/join_block.R
@@ -61,11 +61,18 @@ new_join_block <- function(
           )
         }
 
-        # Send column summary (name + label + type) when either input changes
-        observeEvent(list(x(), y()), send_columns())
+        # Send column summary (name + label + type) when either input changes.
+        # Lower priority than the state push in `js_block_state()`: join
+        # auto-submits once it has columns, so a restored block must have
+        # been told what it is first (see `new_js_transform_block()`).
+        observeEvent(list(x(), y()), send_columns(), priority = -10L)
         # ...and when a client announces itself, which is how a block on a
         # deferred dock panel gets the push that was dropped at boot.
-        observeEvent(input[[js_block_ready_name("join_input")]], send_columns())
+        observeEvent(
+          input[[js_block_ready_name("join_input")]],
+          send_columns(),
+          priority = -10L
+        )
 
         sync <- js_block_state(input, session, "join", "join_input", state)
 

--- a/R/js-block.R
+++ b/R/js-block.R
@@ -78,11 +78,23 @@ new_js_transform_block <- function(class,
             )
           }
 
-          observeEvent(data(), send_columns())
+          # Both of these run at a LOWER priority than the state pushes in
+          # `js_block_state()`, so a restored block always learns what it is
+          # before it learns what columns exist. The other way round, a block
+          # that auto-submits once columns arrive (summarize, join) sends its
+          # fresh, auto-picked reading of itself first, and that input write
+          # lands in the per-field reactiveVals -- overwriting the very state
+          # that was about to be pushed to it. `self_write` then suppresses
+          # the correcting echo, so R and the client quietly disagree.
+          observeEvent(data(), send_columns(), priority = -10L)
           # Deferred panel: this push was dropped at boot (see js_block_state).
           # Without it the column pickers stay EMPTY and the block cannot be
           # configured at all, restored state or not.
-          observeEvent(input[[js_block_ready_name(input_name)]], send_columns())
+          observeEvent(
+            input[[js_block_ready_name(input_name)]],
+            send_columns(),
+            priority = -10L
+          )
         }
 
         if (!is.null(setup)) {
@@ -210,6 +222,9 @@ js_block_state <- function(input, session, name, input_name, state,
   # target isn't `.shiny-bound-input` yet (shiny.js inputMessages handler).
   # The custom channel's `_enqueue`/`_replayPending` (blockr-core.js) is that
   # missing client-side queue, replaying on `initialize()`.
+  #
+  # Priority 0 against the columns pushes' -10: state first, always. See
+  # `new_js_transform_block()` for what the other order costs.
   observeEvent(r_state(), {
     if (self_write$active) {
       self_write$active <- FALSE

--- a/inst/js/arrange-block.js
+++ b/inst/js/arrange-block.js
@@ -27,9 +27,14 @@
   /**
    * Internal per-row UI record.
    * @typedef {Object} ArrangeRow
+   * `colPinned` marks a column the board restored or the user picked, as
+   * opposed to one the select auto-picked (option 0) on its own. Only a
+   * pinned column survives a column list that does not offer it — see
+   * updateColumns().
    * @property {number} id
    * @property {string} column
    * @property {'asc' | 'desc'} direction
+   * @property {boolean} colPinned
    * @property {BlockrSelectSingleHandle | null} _colSelect
    * @property {HTMLDivElement | null} rowEl
    * @property {HTMLButtonElement} [_dirBtn]
@@ -89,6 +94,9 @@
         id,
         column: column || '',
         direction: direction || 'asc',
+        // A column handed to us came from the board or the user; one the
+        // select picks on its own does not.
+        colPinned: !!column,
         _colSelect: null,
         rowEl: null
       };
@@ -108,6 +116,7 @@
         placeholder: 'Column\u2026',
         onChange: (value) => {
           row.column = value;
+          row.colPinned = true;
           this._submit();
         }
       });
@@ -224,11 +233,10 @@
         this.columnOptions.push({ value: col.name, label: col.label || '' });
       }
       for (const r of this.rows) {
-        if (r._colSelect) {
-          const current = r._colSelect.getValue();
-          r._colSelect.setOptions(this.columnOptions, current);
-          r.column = r._colSelect.getValue();
-        }
+        if (!r._colSelect) continue;
+        r.column = Blockr.reconcileColumn(
+          r._colSelect, this.columnOptions, r.column, r.colPinned
+        );
       }
     }
   }

--- a/inst/js/blockr-core.js
+++ b/inst/js/blockr-core.js
@@ -225,6 +225,101 @@ Blockr.icons = {
 };
 
 /**
+ * Point a column picker at a new option list without losing a deliberate pick.
+ *
+ * The BLOCK owns its column; the widget does not. Reading the pick back out of
+ * the select after `setOptions()` and storing that as block state is what used
+ * to lose a restored board: a column picker has no `allowEmpty`, so a list that
+ * does not carry the block's column slides the widget onto option 0 — and
+ * during a restore that list arrives routinely, because an upstream still
+ * settling means `data()` is the OLD frame. The block adopted the fallback,
+ * and nothing recovered it: `setState()` rebuilds from R's message, which does
+ * not repeat. rename renamed a column nobody named, filter kept its values
+ * while re-pointing at another column.
+ *
+ * So the two cases have to be told apart:
+ *   pinned   — the board restored this column, or the user picked it. It
+ *              survives a list that does not offer it (`updateOptions` swaps
+ *              the list without touching the selection, so the face keeps
+ *              showing it) and lands back on its option when the real columns
+ *              arrive.
+ *   unpinned — nothing but the select's own auto-pick of option 0, which is
+ *              not a decision. It still follows the list, so re-pointing the
+ *              block at different data moves it — and the face keeps matching
+ *              the value.
+ *
+ * @param {BlockrSelectSingleHandle} select
+ * @param {BlockrSelectOption[]} options
+ * @param {string} column The owner's column, not the widget's.
+ * @param {boolean} pinned
+ * @returns {string} The column the owner should hold from here on.
+ */
+Blockr.reconcileColumn = (select, options, column, pinned) => {
+  const offered = (options || []).map(
+    (o) => (o && typeof o === 'object' ? o.value : o)
+  );
+  if (pinned && column && offered.indexOf(column) < 0) {
+    select.updateOptions(options, column);
+    return column;
+  }
+  select.setOptions(options, column || null);
+  return select.getValue() || '';
+};
+
+/**
+ * A comparable key for a block state, insensitive to key order and to the
+ * scalar/length-1-array distinction.
+ *
+ * For deciding whether a block has anything new to tell R. A submit is not
+ * free: `js_block_state()` writes the blob into the per-field reactiveVals and
+ * arms `self_write` to swallow the echo, so a submit that says nothing costs a
+ * round trip and leaves the guard armed against the next real change. What R
+ * sent us is not news.
+ *
+ * A length-1 array and its bare element are the SAME value on the wire, so
+ * they have to key the same: jsonlite auto-unboxes, and a single group-by
+ * column reaches the client as `by: "Species"` while `_compose()` holds
+ * `["Species"]`. Keying those apart made every restore with one group-by
+ * column echo itself straight back at R, which is the case this guard exists
+ * to stop. Unwrapping both sides cannot hide a real difference: the values
+ * underneath are still compared.
+ *
+ * @param {unknown} state
+ * @returns {string}
+ */
+Blockr.stateKey = (state) => JSON.stringify(state, (_key, value) => {
+  if (Array.isArray(value)) return value.length === 1 ? value[0] : value;
+  return value && typeof value === 'object'
+    ? Object.keys(value).sort().reduce((sorted, k) => {
+      sorted[k] = value[k];
+      return sorted;
+    }, /** @type {Record<string, unknown>} */ ({}))
+    : value;
+});
+
+/**
+ * The same, for a multi column picker.
+ *
+ * There is no auto-pick to tell apart here — a multi select never chooses
+ * anything on its own, so everything in it was restored or picked, and all of
+ * it is pinned. `setOptions()` would FILTER the selection against the new
+ * list, which during a restore means a block whose columns the current frame
+ * does not carry yet comes back EMPTY: no columns selected, no columns to
+ * pivot, no group-by. Nothing brings them back either, so the next submit
+ * writes the empty version over the board's.
+ *
+ * @param {BlockrSelectMultiHandle} select
+ * @param {BlockrSelectOption[]} options
+ * @param {string[]} columns The owner's columns, not the widget's.
+ * @returns {string[]} The columns the owner should hold from here on.
+ */
+Blockr.reconcileColumns = (select, options, columns) => {
+  const cols = (columns || []).slice();
+  select.updateOptions(options, cols);
+  return cols;
+};
+
+/**
  * Toggle the canonical required-empty amber cue (blockr-blocks.css
  * .blockr-field--required-empty) on a field wrapper or standalone input.
  * One name keeps call sites greppable for the blockr.ui move.

--- a/inst/js/blockr-select.js
+++ b/inst/js/blockr-select.js
@@ -660,12 +660,27 @@
         return mode === 'single' ? (selected || '') : selected.slice();
       },
 
-      // Swap the option list without touching the current selection (setOptions
-      // filters selected against the new options, which would drop chips whose
-      // value list hasn't arrived yet). Used by lazy value loading.
-      /** @param {BlockrSelectOption[] | BlockrSelectOption | null | undefined} opts */
-      updateOptions(opts) {
+      // Swap the option list without reconciling the selection against it
+      // (setOptions filters selected against the new options, which would drop
+      // chips whose value list hasn't arrived yet). Used by lazy value loading.
+      //
+      // `sel` forces the selection instead of leaving it alone — for a caller
+      // that OWNS the value and is only borrowing the widget to display it,
+      // e.g. a column picker showing the column a board restored while the
+      // frame that has it is still loading (Blockr.reconcileColumn). Nothing
+      // else may set a selection the option list does not contain: use
+      // setOptions() and let it reconcile.
+      /**
+       * @param {BlockrSelectOption[] | BlockrSelectOption | null | undefined} opts
+       * @param {string | string[] | null} [sel]
+       */
+      updateOptions(opts, sel) {
         options = Array.isArray(opts) ? opts : (opts != null ? [opts] : []);
+        if (sel != null) {
+          selected = mode === 'multi'
+            ? (Array.isArray(sel) ? sel.slice() : [sel])
+            : sel;
+        }
         render();
         if (isOpen) computePosition();
       },

--- a/inst/js/filter-block.js
+++ b/inst/js/filter-block.js
@@ -54,10 +54,15 @@
   /**
    * Internal per-condition row record (UI state; composed into a
    * BlockrFilterCondition by _compose()).
+   * `colPinned` marks a column the board restored or the user picked, as
+   * opposed to one the select auto-picked (option 0) on its own — only a
+   * pinned column survives a column list that does not offer it (see
+   * updateColumns()).
    * @typedef {Object} FilterCondRow
    * @property {number} id
    * @property {'none' | 'values' | 'numeric' | 'expr'} filterType
    * @property {string | null} column
+   * @property {boolean} colPinned
    * @property {string} [op]
    * @property {string[] | null} values
    * @property {number | null} numValue
@@ -211,13 +216,32 @@
       // { op: c.op } — if cond.op is left at the default 'is' here, an
       // initial state of mode='exclude' (op='is not') gets clobbered the
       // moment columns load. Same for numeric ops ('>', '<=', etc.).
+      // Coerce scalar → [scalar] here as well as in _onColumnChange: R → JSON
+      // auto-unboxing flattens a length-1 character vector to a string, and a
+      // restored row is composed from these fields before _onColumnChange has
+      // ever run (see filterType below).
+      const rawVals = opts?.values;
+      const values = Array.isArray(rawVals)
+        ? rawVals.slice()
+        : (rawVals == null || rawVals === '' ? [] : [rawVals]);
+
       /** @type {FilterCondRow} */
       const cond = {
         id,
-        filterType: 'none',
+        // A restored row knows its own kind from its saved state; only a fresh
+        // row has to wait for column metadata to find out. Leaving this at
+        // 'none' until metadata arrives is what used to make _compose() DROP a
+        // restored condition whose column the current frame does not carry (an
+        // upstream still settling) — the next submit then wrote an empty
+        // filter over the board's. _onColumnChange overwrites it, from the
+        // column's real type, the moment that metadata lands.
+        filterType: values.length ? 'values' : (opts?.numValue != null ? 'numeric' : 'none'),
         column: column || '',
+        // A column handed to us came from the board or the user; one the
+        // select picks on its own does not.
+        colPinned: !!column,
         op: opts?.op || 'is',
-        values: /** @type {string[]} */ (opts?.values || []),
+        values,
         numValue: opts?.numValue ?? null,
         // Saved colType from a restored state — used by _compose until live
         // column metadata arrives and takes precedence.
@@ -241,6 +265,7 @@
         selected: /** @type {string | undefined} */ (column),
         placeholder: 'Column\u2026',
         onChange: (value) => {
+          cond.colPinned = true;
           this._onColumnChange(cond, value);
           this._syncColWidth();
         }
@@ -438,6 +463,8 @@
         id,
         filterType: 'expr',
         column: null,
+        // No column picker on an expression row, so nothing to pin.
+        colPinned: false,
         values: null,
         numValue: null,
         multiSelect: null,
@@ -605,9 +632,10 @@
       }
       for (const c of this.conditions) {
         if (c._colSelectize) {
-          const current = c._colSelectize.getValue();
-          c._colSelectize.setOptions(this.columnOptions, current);
-          const col = c._colSelectize.getValue();
+          const col = Blockr.reconcileColumn(
+            c._colSelectize, this.columnOptions, c.column || '', c.colPinned
+          );
+          c.column = col;
           if (col && this.columnMeta[col]) {
             // Preserve existing values/op: column metadata refreshing must
             // not clobber user- or setState-provided condition values.
@@ -617,6 +645,11 @@
               op: c.op
             });
           }
+          // A pinned column the frame does not carry keeps its row as it
+          // stands — values, operator and `_savedColType` all intact — so
+          // _compose() still ships the condition the board restored while the
+          // upstream settles. Re-rendering it against absent metadata would
+          // throw the values away.
         }
         if (c.exprInput) {
           c.exprInput.setColumns(this.columnNames);

--- a/inst/js/join-block.js
+++ b/inst/js/join-block.js
@@ -34,12 +34,17 @@
  */
 
 /**
- * Internal key-row record: the key model plus its UI handles.
+ * Internal key-row record: the key model plus its UI handles. `xPinned` /
+ * `yPinned` mark a column the board restored or the user picked, as opposed
+ * to one a select auto-picked (option 0) on its own — only a pinned column
+ * survives a column list that does not offer it (see updateColumns()).
  * @typedef {Object} JoinKeyRow
  * @property {number} id
  * @property {string} xCol
  * @property {string} op
  * @property {string} yCol
+ * @property {boolean} xPinned
+ * @property {boolean} yPinned
  * @property {BlockrSelectSingleHandle | null} _xSelectize
  * @property {BlockrSelectSingleHandle | null} _ySelectize
  * @property {HTMLButtonElement} [_opBtn] Assigned right after row creation.
@@ -281,6 +286,11 @@
         xCol: xCol || '',
         op: op || '==',
         yCol: yCol || '',
+        // Columns handed to us came from the board or the user; ones the
+        // selects pick on their own do not. Only a pinned column survives a
+        // column list that does not offer it — see updateColumns().
+        xPinned: !!xCol,
+        yPinned: !!yCol,
         _xSelectize: null,
         _ySelectize: null,
         rowEl: null
@@ -302,6 +312,7 @@
         placeholder: 'x column\u2026',
         onChange: (value) => {
           key.xCol = value;
+          key.xPinned = true;
           this._syncColWidth();
           this._submit();
         }
@@ -335,6 +346,7 @@
         placeholder: 'y column\u2026',
         onChange: (value) => {
           key.yCol = value;
+          key.yPinned = true;
           this._submit();
         }
       });
@@ -580,6 +592,7 @@
      * @param {BlockrPickerColumn[] | null | undefined} yMeta
      */
     updateColumns(xMeta, yMeta) {
+      const before = Blockr.stateKey(this._compose());
       this.xColumnMeta = {};
       this.xColumns = [];
       this.xColumnOptions = [];
@@ -597,17 +610,20 @@
         this.yColumnOptions.push({ value: col.name, label: col.label || '' });
       }
 
-      // Update key row selectizes
+      // Update key row selectizes. A key row owns its columns; the widgets do
+      // not. Both sides restore independently, and either upstream can still
+      // be settling when its column list arrives — a key that adopted the
+      // select's fallback would join on a column nobody chose.
       for (const k of this.keys) {
         if (k._xSelectize) {
-          const curX = k._xSelectize.getValue();
-          k._xSelectize.setOptions(this.xColumnOptions, curX);
-          k.xCol = k._xSelectize.getValue();
+          k.xCol = Blockr.reconcileColumn(
+            k._xSelectize, this.xColumnOptions, k.xCol, k.xPinned
+          );
         }
         if (k._ySelectize) {
-          const curY = k._ySelectize.getValue();
-          k._ySelectize.setOptions(this.yColumnOptions, curY);
-          k.yCol = k._ySelectize.getValue();
+          k.yCol = Blockr.reconcileColumn(
+            k._ySelectize, this.yColumnOptions, k.yCol, k.yPinned
+          );
         }
       }
 
@@ -621,8 +637,9 @@
 
       this._syncColWidth();
 
-      // Auto-submit now that columns are available
-      this._submit();
+      // Auto-submit now that columns are available -- but only if knowing
+      // them changed what this block would send (see summarize-block.js).
+      if (Blockr.stateKey(this._compose()) !== before) this._submit();
     }
   }
 

--- a/inst/js/mutate-block.js
+++ b/inst/js/mutate-block.js
@@ -5,7 +5,7 @@
  * Each row: [name_input] = [Blockr.Input expression] [confirm] [remove]
  * Expression-only mode with confirm-on-Enter pattern.
  *
- * Depends on: blockr-core.js, blockr-input.js
+ * Depends on: blockr-core.js, blockr-select.js, blockr-input.js
  */
 
 /**
@@ -300,16 +300,24 @@
           r.confirmBtn?.classList.add('confirmed');
           if (r.confirmBtn) r.confirmBtn.innerHTML = Blockr.icons.confirm;
         }
-        if (!silent) this._submit();
       }
       // Update group by (ensure array — R may send scalar string)
       const by = state?.by || [];
       this.byValues = Array.isArray(by) ? by.slice() : [by];
       if (this._bySelect) {
-        this._bySelect.setOptions(this.columnOptions, this.byValues);
+        Blockr.reconcileColumns(this._bySelect, this.columnOptions, this.byValues);
       }
 
       this._updateUI();
+
+      // Answer R only if our reading of what it sent differs from what it
+      // sent. This used to submit halfway through the rebuild, before `by`
+      // had been restored, so it shipped the PREVIOUS by -- and
+      // `js_block_state()` writes an input blob straight into the per-field
+      // reactiveVals, so the board's group-by was gone.
+      if (!silent && Blockr.stateKey(this._compose()) !== Blockr.stateKey(state || {})) {
+        this._submit();
+      }
     }
 
     /** @param {BlockrPickerColumn[] | null | undefined} meta */
@@ -326,7 +334,7 @@
         r.exprInput?.setColumns(this.columnNames);
       }
       if (this._bySelect) {
-        this._bySelect.setOptions(this.columnOptions, this.byValues);
+        Blockr.reconcileColumns(this._bySelect, this.columnOptions, this.byValues);
       }
     }
   }

--- a/inst/js/pivot-longer-block.js
+++ b/inst/js/pivot-longer-block.js
@@ -268,7 +268,7 @@
 
       // Update multi-select
       if (this._multiSelect) {
-        this._multiSelect.setOptions(this.columnOptions, this.cols);
+        Blockr.reconcileColumns(this._multiSelect, this.columnOptions, this.cols);
       }
       this._updateRequired();
     }
@@ -284,8 +284,9 @@
         this.columnOptions.push({ value: col.name, label: col.label || '' });
       }
       if (this._multiSelect) {
-        this._multiSelect.setOptions(this.columnOptions, this.cols);
-        this.cols = this._multiSelect.getValue();
+        this.cols = Blockr.reconcileColumns(
+          this._multiSelect, this.columnOptions, this.cols
+        );
       }
       this._updateRequired();
     }

--- a/inst/js/pivot-wider-block.js
+++ b/inst/js/pivot-wider-block.js
@@ -305,13 +305,13 @@
 
       // Update multi-selects
       if (this._namesFromSelect) {
-        this._namesFromSelect.setOptions(this.columnOptions, this.names_from);
+        Blockr.reconcileColumns(this._namesFromSelect, this.columnOptions, this.names_from);
       }
       if (this._valuesFromSelect) {
-        this._valuesFromSelect.setOptions(this.columnOptions, this.values_from);
+        Blockr.reconcileColumns(this._valuesFromSelect, this.columnOptions, this.values_from);
       }
       if (this._idColsSelect) {
-        this._idColsSelect.setOptions(this.columnOptions, this.id_cols);
+        Blockr.reconcileColumns(this._idColsSelect, this.columnOptions, this.id_cols);
       }
       this._updateRequired();
     }
@@ -327,16 +327,19 @@
         this.columnOptions.push({ value: col.name, label: col.label || '' });
       }
       if (this._namesFromSelect) {
-        this._namesFromSelect.setOptions(this.columnOptions, this.names_from);
-        this.names_from = this._namesFromSelect.getValue();
+        this.names_from = Blockr.reconcileColumns(
+          this._namesFromSelect, this.columnOptions, this.names_from
+        );
       }
       if (this._valuesFromSelect) {
-        this._valuesFromSelect.setOptions(this.columnOptions, this.values_from);
-        this.values_from = this._valuesFromSelect.getValue();
+        this.values_from = Blockr.reconcileColumns(
+          this._valuesFromSelect, this.columnOptions, this.values_from
+        );
       }
       if (this._idColsSelect) {
-        this._idColsSelect.setOptions(this.columnOptions, this.id_cols);
-        this.id_cols = this._idColsSelect.getValue();
+        this.id_cols = Blockr.reconcileColumns(
+          this._idColsSelect, this.columnOptions, this.id_cols
+        );
       }
       this._updateRequired();
     }

--- a/inst/js/rename-block.js
+++ b/inst/js/rename-block.js
@@ -21,11 +21,15 @@
    */
 
   /**
-   * Internal per-row UI record.
+   * Internal per-row UI record. `colPinned` marks a column the board restored
+   * or the user picked, as opposed to one the select auto-picked (option 0) on
+   * its own. Only a pinned column survives a column list that does not offer
+   * it — see updateColumns().
    * @typedef {Object} RenameRow
    * @property {number} id
    * @property {string} oldCol
    * @property {string} newName
+   * @property {boolean} colPinned
    * @property {BlockrSelectSingleHandle | null} _colSelect
    * @property {HTMLDivElement | null} rowEl
    * @property {HTMLInputElement} [_nameInput]
@@ -86,6 +90,9 @@
         id,
         oldCol: oldCol || '',
         newName: newName || '',
+        // A column handed to us came from the board or the user; one the
+        // select picks on its own does not.
+        colPinned: !!oldCol,
         _colSelect: null,
         rowEl: null
       };
@@ -105,6 +112,7 @@
         placeholder: 'Column\u2026',
         onChange: (value) => {
           row.oldCol = value;
+          row.colPinned = true;
           // Auto-populate new name if empty
           if (!row.newName && value) {
             row.newName = value;
@@ -148,9 +156,10 @@
       });
       rowEl.appendChild(rmBtn);
 
-      // Sync row.oldCol with the select's actual value — the select may
-      // auto-pick the first option when oldCol is null/empty.
-      row.oldCol = row._colSelect.getValue() || '';
+      // A row created with no column adopts the select's auto-pick (option 0),
+      // so the face and the value agree. A row that ASKED for one keeps it,
+      // even while `columnOptions` does not carry it — see updateColumns().
+      if (!row.oldCol) row.oldCol = row._colSelect.getValue() || '';
 
       /** @type {HTMLDivElement} */ (this.listEl).appendChild(rowEl);
       this.rows.push(row);
@@ -260,11 +269,10 @@
         this.columnOptions.push({ value: col.name, label: col.label || '' });
       }
       for (const r of this.rows) {
-        if (r._colSelect) {
-          const current = r._colSelect.getValue();
-          r._colSelect.setOptions(this.columnOptions, current);
-          r.oldCol = r._colSelect.getValue();
-        }
+        if (!r._colSelect) continue;
+        r.oldCol = Blockr.reconcileColumn(
+          r._colSelect, this.columnOptions, r.oldCol, r.colPinned
+        );
       }
       this._syncColWidth();
     }

--- a/inst/js/select-block.js
+++ b/inst/js/select-block.js
@@ -121,7 +121,11 @@
       /** @type {BlockrCheckboxHandle} */ (this._distinctBox).set(this.distinct);
 
       if (this._multiSelect) {
-        this._multiSelect.setOptions(this.columnOptions, this.columns);
+        // The block owns `columns`; the widget only shows them. setOptions()
+        // would drop the ones the current option list does not carry, which on
+        // a restore is all of them (state arrives before the first column
+        // push).
+        Blockr.reconcileColumns(this._multiSelect, this.columnOptions, this.columns);
       }
     }
 
@@ -136,8 +140,9 @@
         this.columnOptions.push({ value: col.name, label: col.label || '' });
       }
       if (this._multiSelect) {
-        this._multiSelect.setOptions(this.columnOptions, this.columns);
-        this.columns = this._multiSelect.getValue();
+        this.columns = Blockr.reconcileColumns(
+          this._multiSelect, this.columnOptions, this.columns
+        );
       }
     }
   }

--- a/inst/js/separate-block.js
+++ b/inst/js/separate-block.js
@@ -31,6 +31,11 @@
     constructor(el) {
       this.el = el;
       this.col = '';
+      // True when the board restored the column or the user picked it, as
+      // opposed to the select's own auto-pick of option 0. Only a pinned
+      // column survives a column list that does not offer it — see
+      // updateColumns().
+      this.colPinned = false;
       /** @type {string[]} */
       this.into = [];
       this.sep = '[^[:alnum:]]+';
@@ -78,6 +83,7 @@
         placeholder: 'Select column…',
         onChange: (value) => {
           this.col = value;
+          this.colPinned = true;
           this._updateRequired();
           this._submit();
         }
@@ -210,14 +216,20 @@
      */
     setState(state, silent) {
       this.col = state?.col || '';
+      this.colPinned = !!state?.col;
       this.into = (state?.into || []).slice();
       this.sep = state?.sep ?? '[^[:alnum:]]+';
       this.remove = state?.remove !== false;
       this.convert = !!state?.convert;
 
-      // Update column select
+      // Update column select. `this.col` is already the restored value and
+      // stays authoritative — the reconcile is here so the FACE keeps showing
+      // it when the option list is empty or stale (state usually arrives
+      // before the first column push), instead of blanking to `''`.
       if (this._colSelect) {
-        this._colSelect.setOptions(this.columnOptions, this.col || null);
+        Blockr.reconcileColumn(
+          this._colSelect, this.columnOptions, this.col, this.colPinned
+        );
       }
 
       // Update text inputs (sync resets the chips)
@@ -242,9 +254,9 @@
         this.columnOptions.push({ value: col.name, label: col.label || '' });
       }
       if (this._colSelect) {
-        const current = this._colSelect.getValue();
-        this._colSelect.setOptions(this.columnOptions, current);
-        this.col = this._colSelect.getValue();
+        this.col = Blockr.reconcileColumn(
+          this._colSelect, this.columnOptions, this.col, this.colPinned
+        );
       }
       this._updateRequired();
     }

--- a/inst/js/slice-block.js
+++ b/inst/js/slice-block.js
@@ -41,8 +41,14 @@
       /** @type {number | null} */
       this.prop = null;
       this.order_by = '';
+      // True when the board restored the column or the user picked it. An
+      // `allowEmpty` picker never chooses on its own, so an unpinned column is
+      // always '' — the flag is what tells a deliberate column apart from one
+      // the current frame simply has not delivered yet (see updateColumns).
+      this.orderByPinned = false;
       this.with_ties = true;
       this.weight_by = '';
+      this.weightByPinned = false;
       this.replace = false;
       this.rows = '1:5';
       /** @type {string[]} */
@@ -253,6 +259,7 @@
         placeholder: 'Select column…',
         onChange: (value) => {
           this.order_by = value;
+          this.orderByPinned = !!value;
           this._updateRequired();
           this._submit();
         }
@@ -277,6 +284,7 @@
         placeholder: 'Unweighted',
         onChange: (value) => {
           this.weight_by = value;
+          this.weightByPinned = !!value;
           this._submit();
         }
       });
@@ -407,8 +415,10 @@
       this.n = state?.n ?? 5;
       this.prop = state?.prop ?? null;
       this.order_by = state?.order_by || '';
+      this.orderByPinned = !!this.order_by;
       this.with_ties = state?.with_ties !== false;
       this.weight_by = state?.weight_by || '';
+      this.weightByPinned = !!this.weight_by;
       this.replace = !!state?.replace;
       this.rows = state?.rows || '1:5';
       const byRaw = state?.by || [];
@@ -439,13 +449,17 @@
 
       // Update column selects
       if (this._orderBySelect) {
-        this._orderBySelect.setOptions(this.columnOptions, this.order_by || null);
+        Blockr.reconcileColumn(
+          this._orderBySelect, this.columnOptions, this.order_by, this.orderByPinned
+        );
       }
       if (this._weightBySelect) {
-        this._weightBySelect.setOptions(this.columnOptions, this.weight_by || null);
+        Blockr.reconcileColumn(
+          this._weightBySelect, this.columnOptions, this.weight_by, this.weightByPinned
+        );
       }
       if (this._bySelect) {
-        this._bySelect.setOptions(this.columnOptions, this.by);
+        Blockr.reconcileColumns(this._bySelect, this.columnOptions, this.by);
       }
 
       // Update checkboxes
@@ -468,21 +482,24 @@
       // Refresh options but keep the model state authoritative: a single
       // selectize picks a default when passed null, which would silently
       // commit a column the user never chose (breaks save/restore).
+      //
+      // Dropping a column the new list does not carry was the other half of
+      // that: during a restore the list routinely arrives from an upstream
+      // that has not restored yet, and clearing `order_by` there loses the
+      // board's column for good. A pinned column stays put and lands back on
+      // its option when the real columns arrive.
       if (this._orderBySelect) {
-        this._orderBySelect.setOptions(this.columnOptions, this.order_by || null);
-        if (this.order_by && !this.columnNames.includes(this.order_by)) {
-          this.order_by = "";
-        }
+        this.order_by = Blockr.reconcileColumn(
+          this._orderBySelect, this.columnOptions, this.order_by, this.orderByPinned
+        );
       }
       if (this._weightBySelect) {
-        this._weightBySelect.setOptions(this.columnOptions, this.weight_by || null);
-        if (this.weight_by && !this.columnNames.includes(this.weight_by)) {
-          this.weight_by = "";
-        }
+        this.weight_by = Blockr.reconcileColumn(
+          this._weightBySelect, this.columnOptions, this.weight_by, this.weightByPinned
+        );
       }
       if (this._bySelect) {
-        this._bySelect.setOptions(this.columnOptions, this.by);
-        this.by = (this.by || []).filter(c => this.columnNames.includes(c));
+        this.by = Blockr.reconcileColumns(this._bySelect, this.columnOptions, this.by);
       }
       this._updateRequired();
     }

--- a/inst/js/summarize-block.js
+++ b/inst/js/summarize-block.js
@@ -35,12 +35,16 @@
 /**
  * Internal row record: the summary model plus its UI handles. Simple rows
  * carry func/col and the two selectizes; expr rows carry exprInput.
+ * `colPinned` marks a column the board restored or the user picked, as
+ * opposed to one the select auto-picked (option 0) on its own — only a pinned
+ * column survives a column list that does not offer it (see updateColumns()).
  * @typedef {Object} SummarizeRow
  * @property {number} id
  * @property {'simple' | 'expr'} type
  * @property {string} name
  * @property {string} [func]
  * @property {string} [col]
+ * @property {boolean} [colPinned]
  * @property {HTMLDivElement | null} rowEl
  * @property {BlockrInputHandle} [exprInput]
  * @property {BlockrSelectSingleHandle | null} [_funcSelectize]
@@ -169,6 +173,10 @@
         name: name || '',
         func: func || this.summaryFuncs[0],
         col: col || '',
+        // A column handed to us came from the board or the user; one the
+        // select picks on its own does not. Only a pinned column survives a
+        // column list that does not offer it — see updateColumns().
+        colPinned: !!col,
         rowEl: null,
         _funcSelectize: null,
         _colSelectize: null,
@@ -241,6 +249,7 @@
         placeholder: 'Column\u2026',
         onChange: (value) => {
           summary.col = value;
+          summary.colPinned = true;
           this._submit();
         }
       });
@@ -483,13 +492,17 @@
       const by = Array.isArray(byRaw) ? byRaw.slice() : [byRaw];
       this.byValues = by;
       if (this._bySelectize) {
-        this._bySelectize.setOptions(this.columnOptions, by);
+        Blockr.reconcileColumns(this._bySelectize, this.columnOptions, by);
       }
 
       this._updateUI();
 
-      // Auto-submit if state has content
-      if (summaries.length > 0 && !silent) {
+      // Answer R only if our reading of what it sent differs from what it
+      // sent — typically a name this block generated for a summary that
+      // arrived without one. Echoing an unchanged state back is not free: it
+      // writes the blob into R's per-field reactiveVals and arms `self_write`
+      // against the next real change (see Blockr.stateKey).
+      if (!silent && Blockr.stateKey(this._compose()) !== Blockr.stateKey(state || {})) {
         this._submit();
       }
     }
@@ -540,6 +553,7 @@
 
     /** @param {BlockrPickerColumn[] | null | undefined} meta */
     updateColumns(meta) {
+      const before = Blockr.stateKey(this._compose());
       this.columnMeta = {};
       this.columnNames = [];
       this.columnOptions = [];
@@ -549,14 +563,21 @@
         this.columnOptions.push({ value: col.name, label: col.label || '' });
       }
 
-      // Refresh simple-row column pickers, but do not auto-assign a default
-      // column to a row that legitimately has none (e.g. func = "n"), and
-      // only clear the stored column if it has actually been removed.
+      // Refresh simple-row column pickers. A row that legitimately has no
+      // column (e.g. func = "n") must not be auto-assigned one, and a row that
+      // HAS one keeps it even when this list does not carry it: clearing there
+      // dropped the whole summary from _compose(), and the _submit() at the
+      // end of this method wrote that empty version straight back to R.
       for (const s of this.summaries) {
         if (s.type === 'simple' && s._colSelectize) {
-          s._colSelectize.setOptions(this.columnOptions, s.col || null);
-          if (s.col && !this.columnNames.includes(s.col)) {
-            s.col = "";
+          if (NO_COL_FUNCS.includes(/** @type {string} */ (s.func))) {
+            // This row takes no column (n()), so "" is its answer, not a gap
+            // waiting to be filled: refresh the list and leave the row alone.
+            s._colSelectize.setOptions(this.columnOptions, null);
+          } else {
+            s.col = Blockr.reconcileColumn(
+              s._colSelectize, this.columnOptions, s.col || '', s.colPinned
+            );
           }
         }
         if (s.exprInput) {
@@ -564,16 +585,19 @@
         }
       }
 
-      // Refresh group-by selectize and drop removed columns from model
+      // Refresh the group-by selectize; the model stays authoritative
       if (this._bySelectize) {
-        this._bySelectize.setOptions(this.columnOptions, this.byValues);
-        this.byValues = (this.byValues || []).filter(
-          c => this.columnNames.includes(c)
+        this.byValues = Blockr.reconcileColumns(
+          this._bySelectize, this.columnOptions, this.byValues
         );
       }
 
-      // Auto-submit now that columns are available
-      this._submit();
+      // Auto-submit now that columns are available -- but only if knowing
+      // them changed what this block would send. A fresh block picks its first
+      // column here and R has to hear about it; a restored one has nothing new
+      // to say, and saying it anyway wrote the client's reading over the state
+      // R had just restored (see Blockr.stateKey).
+      if (Blockr.stateKey(this._compose()) !== before) this._submit();
     }
   }
 

--- a/inst/js/types.d.ts
+++ b/inst/js/types.d.ts
@@ -145,10 +145,16 @@ interface BlockrSelectHandleBase {
     sel?: string | string[] | null
   ): void;
   /**
-   * Swap the option list without touching the current selection (setOptions
-   * would drop chips whose value list hasn't arrived yet). Lazy loading.
+   * Swap the option list without reconciling the selection against it
+   * (setOptions would drop chips whose value list hasn't arrived yet). Lazy
+   * loading, and — with `sel` — a caller that owns the value and is only
+   * borrowing the widget to display it: `sel` is forced, option list or not.
+   * See Blockr.reconcileColumn.
    */
-  updateOptions(opts: BlockrSelectOption[] | BlockrSelectOption | null | undefined): void;
+  updateOptions(
+    opts: BlockrSelectOption[] | BlockrSelectOption | null | undefined,
+    sel?: string | string[] | null
+  ): void;
   /** Toggle the "Loading…" dropdown state. */
   setLoading(flag: boolean): void;
   /**
@@ -276,6 +282,30 @@ interface BlockrNamespace {
     checked: boolean,
     onChange: (checked: boolean) => void
   ): BlockrCheckboxHandle;
+  /**
+   * Point a column picker at a new option list without losing a deliberate
+   * pick. Returns the column the caller should hold from here on: a pinned
+   * one (restored or user-picked) survives a list that does not offer it, an
+   * unpinned one still follows the list. See blockr-core.js.
+   */
+  reconcileColumn(
+    select: BlockrSelectSingleHandle,
+    options: BlockrSelectOption[],
+    column: string,
+    pinned: boolean | undefined
+  ): string;
+  /** The same for a multi picker, where everything selected is pinned. */
+  reconcileColumns(
+    select: BlockrSelectMultiHandle,
+    options: BlockrSelectOption[],
+    columns: string[] | null | undefined
+  ): string[];
+  /**
+   * Serialization for "has this state changed?": insensitive to key order,
+   * and to the scalar/length-1-array distinction jsonlite's auto-unboxing
+   * puts on the wire. See blockr-core.js.
+   */
+  stateKey(state: unknown): string;
   /** Toggle the canonical required-empty amber cue on a field wrapper. */
   setRequiredEmpty(el: Element, empty: boolean): void;
   /** Commit-on-Enter text input with the "Enter ↵" chip (§5.5). */

--- a/inst/js/unite-block.js
+++ b/inst/js/unite-block.js
@@ -213,7 +213,7 @@
 
       // Update multi-select
       if (this._multiSelect) {
-        this._multiSelect.setOptions(this.columnOptions, this.cols);
+        Blockr.reconcileColumns(this._multiSelect, this.columnOptions, this.cols);
       }
       this._updateRequired();
     }
@@ -229,8 +229,9 @@
         this.columnOptions.push({ value: col.name, label: col.label || '' });
       }
       if (this._multiSelect) {
-        this._multiSelect.setOptions(this.columnOptions, this.cols);
-        this.cols = this._multiSelect.getValue();
+        this.cols = Blockr.reconcileColumns(
+          this._multiSelect, this.columnOptions, this.cols
+        );
       }
       this._updateRequired();
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,127 @@
+{
+  "name": "blockr.dplyr",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "blockr.dplyr",
+      "version": "1.0.0",
+      "license": "ISC",
+      "devDependencies": {
+        "happy-dom": "^20.11.2"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "26.2.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.2.0.tgz",
+      "integrity": "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/@types/whatwg-mimetype": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+      "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/buffer-image-size": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/buffer-image-size/-/buffer-image-size-0.6.4.tgz",
+      "integrity": "sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/happy-dom": {
+      "version": "20.11.2",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.11.2.tgz",
+      "integrity": "sha512-7MB+bJLkxu3SowAfBJbjW+c55kNz5tkR45gu2qzrxznezhLeN5YIlJbwUgSzlGc+qWoZ8Ykg71H5ezz69xixrw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=20.0.0",
+        "@types/whatwg-mimetype": "^3.0.2",
+        "@types/ws": "^8.18.1",
+        "buffer-image-size": "^0.6.4",
+        "entities": "^7.0.1",
+        "whatwg-mimetype": "^3.0.0",
+        "ws": "^8.21.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "blockr.dplyr",
+  "private": true,
+  "description": "Test harness for the block JavaScript in inst/js (see tests/js/).",
+  "type": "commonjs",
+  "scripts": {
+    "test": "node --test tests/js/*.test.js"
+  },
+  "devDependencies": {
+    "happy-dom": "^20.11.2"
+  }
+}

--- a/tests/js/column-restore.test.js
+++ b/tests/js/column-restore.test.js
@@ -1,0 +1,349 @@
+/* A block owns its column; the select widget does not.
+ *
+ * `Blockr.Select` in single mode has no `allowEmpty` for a column picker, so
+ * `setOptions(opts, sel)` with a `sel` the new list does not carry slides the
+ * widget onto option 0 (blockr-select.js). Four blocks used to read that pick
+ * back out of the widget and store it as block state:
+ *
+ *   const current = widget.getValue();
+ *   widget.setOptions(this.columnOptions, current);
+ *   <block state> = widget.getValue();          // believe the widget
+ *
+ * A restore delivers exactly the column list that breaks this: while an
+ * upstream is still settling, `data()` is the OLD frame, so R pushes columns
+ * that do not include the ones the restored state names. Every pick collapsed
+ * onto column 1 and never came back — `setState()` rebuilds from R's message,
+ * which does not repeat. rename renamed the wrong column and filter kept its
+ * values while re-pointing at another column, both of which change the data
+ * that flows downstream, silently.
+ *
+ * The two cases the reconcile has to tell apart:
+ *   pinned   — the board restored this column, or the user picked it. It
+ *              survives a list that does not offer it, and lands back on its
+ *              option when the real columns arrive.
+ *   unpinned — nothing but the select's own auto-pick of option 0. It still
+ *              follows the list, so re-pointing the block at different data
+ *              moves it.
+ */
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert');
+const { mount } = require('./harness.js');
+
+/* The frames in the reproduction: a board saved against `iris` whose upstream
+ * has not restored yet, so the first column push is the wrong frame. */
+const IRIS = ['Sepal.Length', 'Sepal.Width', 'Petal.Length', 'Species'];
+const OTHER = ['a', 'b', 'c'];
+
+/* Same frame, with the value lists a small frame's metadata carries — filter
+ * renders its value picker from these without a lazy round trip. */
+const IRIS_VALUES = IRIS.map((name) => ({
+  name,
+  label: '',
+  type: name === 'Species' ? 'character' : 'numeric',
+  values: name === 'Species' ? ['setosa', 'versicolor', 'virginica'] : undefined,
+  uniqueValues: name === 'Species' ? undefined : [1, 2, 3]
+}));
+
+/**
+ * Each block, its restored state, and how to read the columns back out of
+ * what it would send to R.
+ */
+const BLOCKS = [
+  {
+    name: 'arrange',
+    state: { columns: [{ column: 'Species', direction: 'desc' }] },
+    columnsOf: (s) => s.columns.map((c) => c.column),
+    picked: ['Species']
+  },
+  {
+    name: 'rename',
+    state: { renames: { species_name: 'Species' } },
+    columnsOf: (s) => Object.values(s.renames),
+    picked: ['Species']
+  },
+  {
+    name: 'separate',
+    state: { col: 'Species', into: ['genus', 'epithet'], sep: '_', remove: true, convert: false },
+    columnsOf: (s) => (s.col ? [s.col] : []),
+    picked: ['Species']
+  },
+  {
+    name: 'filter',
+    state: {
+      conditions: [
+        { type: 'values', column: 'Species', values: ['setosa'], mode: 'include', colType: 'character' }
+      ],
+      operator: '&',
+      preserve_order: false
+    },
+    columnsOf: (s) => s.conditions.map((c) => c.column),
+    picked: ['Species'],
+    // A column with no values is not yet a filter — _compose() rightly emits
+    // nothing for it — so the pick has to be completed with a value before
+    // there is anything to check the column of.
+    pickColumns: IRIS_VALUES,
+    afterPick: (b) => b.pickNth(1, '1')
+  }
+];
+
+for (const blk of BLOCKS) {
+  const { name, state, columnsOf, picked } = blk;
+
+  test(`${name}: a restored column survives a column list that does not offer it`, () => {
+    const b = mount(name);
+    b.setState(state);
+    // The upstream has not restored yet: the wrong frame's columns.
+    b.columns(OTHER);
+    assert.deepStrictEqual(
+      columnsOf(b.compose()), picked,
+      'the block adopted the select\'s fallback instead of keeping its column'
+    );
+    // ...and the user sees the column the board asked for, not a name
+    // nobody picked.
+    assert.ok(b.faces().includes('Species'), `the select shows [${b.faces()}]`);
+    b.close();
+  });
+
+  test(`${name}: the restored column lands back on its option when the real columns arrive`, () => {
+    const b = mount(name);
+    b.setState(state);
+    b.columns(OTHER);
+    b.columns(IRIS);
+    assert.deepStrictEqual(columnsOf(b.compose()), picked);
+    assert.ok(b.faces().includes('Species'));
+    b.close();
+  });
+
+  test(`${name}: restore round-trips when the columns arrive first`, () => {
+    const b = mount(name);
+    b.columns(IRIS);
+    b.setState(state);
+    assert.deepStrictEqual(b.compose(), state);
+    b.close();
+  });
+
+  test(`${name}: restore round-trips when the state arrives first`, () => {
+    const b = mount(name);
+    b.setState(state);
+    b.columns(IRIS);
+    assert.deepStrictEqual(b.compose(), state);
+    b.close();
+  });
+
+  test(`${name}: a column list still never submits on its own`, () => {
+    // R pushes state and columns; neither is a user edit. A submit here
+    // would write the client's guess back over R's state — the loop
+    // `js_block_state()`'s `self_write` guard exists to prevent.
+    const b = mount(name);
+    b.setState(state);
+    b.columns(OTHER);
+    b.columns(IRIS);
+    assert.deepStrictEqual(b.submits, []);
+    assert.strictEqual(b.value(), null, 'Shiny would have read a value R never asked for');
+    b.close();
+  });
+
+  test(`${name}: a user pick survives a column list that does not offer it`, () => {
+    const b = mount(name);
+    b.columns(blk.pickColumns || IRIS);
+    b.pickNth(0, 'Petal.Length');
+    if (blk.afterPick) blk.afterPick(b);
+    assert.deepStrictEqual(columnsOf(b.compose()), ['Petal.Length']);
+
+    b.columns(OTHER);
+    assert.deepStrictEqual(
+      columnsOf(b.compose()), ['Petal.Length'],
+      'a deliberate pick is as pinned as a restored one'
+    );
+    b.close();
+  });
+
+  test(`${name}: an unpicked column still follows the data`, () => {
+    // Nothing was ever chosen here — the select's auto-pick of option 0 is
+    // not a decision, so re-pointing the block at another frame must move
+    // it rather than strand it on a column that no longer exists.
+    const b = mount(name);
+    b.columns(IRIS);
+    const auto = columnsOf(b.compose());
+    b.columns(OTHER);
+    const moved = columnsOf(b.compose());
+
+    for (const col of moved) {
+      assert.ok(OTHER.includes(col), `stranded on "${col}", which the data no longer has`);
+    }
+    if (auto.length) assert.notDeepStrictEqual(moved, auto);
+    b.close();
+  });
+}
+
+/* --- what each block does with the wrong column, spelled out ----------- */
+
+test('rename does not rename a column the board never named', () => {
+  const b = mount('rename');
+  b.setState({ renames: { species_name: 'Species' } });
+  b.columns(OTHER);
+  assert.deepStrictEqual(
+    b.compose().renames, { species_name: 'Species' },
+    'renaming the wrong column changes the schema every downstream block sees'
+  );
+  b.close();
+});
+
+test('filter keeps its values with its own column, not another one', () => {
+  const b = mount('filter');
+  b.columns(IRIS);
+  b.setState({
+    conditions: [
+      { type: 'values', column: 'Species', values: ['setosa'], mode: 'include', colType: 'character' }
+    ],
+    operator: '&',
+    preserve_order: false
+  });
+  b.columns(OTHER);
+
+  const cond = b.compose().conditions[0];
+  assert.strictEqual(cond.column, 'Species');
+  assert.deepStrictEqual(cond.values, ['setosa']);
+  // "Species is setosa" becoming "Sepal.Length is setosa" is an empty result
+  // with no error anywhere — the failure this whole file is about.
+  b.close();
+});
+
+test('filter keeps the column type it was restored with while the column is away', () => {
+  // _compose() reads colType from live column metadata, falling back to the
+  // restored `_savedColType`. A column the current frame does not carry has
+  // no live metadata, so the fallback is what stops R from guessing the type
+  // by coercibility ("007" must not become 7).
+  const b = mount('filter');
+  b.setState({
+    conditions: [
+      { type: 'values', column: 'id', values: ['007'], mode: 'include', colType: 'character' }
+    ],
+    operator: '&',
+    preserve_order: false
+  });
+  b.columns(OTHER);
+  assert.strictEqual(b.compose().conditions[0].colType, 'character');
+  b.close();
+});
+
+test('arrange keeps its sort directions with its columns', () => {
+  const b = mount('arrange');
+  b.setState({
+    columns: [
+      { column: 'Species', direction: 'desc' },
+      { column: 'Petal.Length', direction: 'asc' }
+    ]
+  });
+  b.columns(OTHER);
+  assert.deepStrictEqual(b.compose().columns, [
+    { column: 'Species', direction: 'desc' },
+    { column: 'Petal.Length', direction: 'asc' }
+  ]);
+  b.close();
+});
+
+test('rename keeps one row per column, not two rows on the first one', () => {
+  // Two rows collapsing onto the same column is worse than a wrong name:
+  // `renames` is keyed by new name, so both rows survive as keys but point
+  // at one source column, and the second rename fails.
+  const b = mount('rename');
+  b.setState({ renames: { len: 'Sepal.Length', sp: 'Species' } });
+  b.columns(OTHER);
+  assert.deepStrictEqual(b.compose().renames, { len: 'Sepal.Length', sp: 'Species' });
+  b.close();
+});
+
+/* --- multi column pickers: the same rule, one plural --------------- */
+
+const MULTI = [
+  { name: 'select', field: 'columns', state: { columns: ['Species', 'Petal.Length'], exclude: false, distinct: false } },
+  { name: 'unite', field: 'cols', state: { col: 'u', cols: ['Species', 'Petal.Length'], sep: '_', remove: true, na_rm: false } },
+  { name: 'pivot-longer', field: 'cols', state: { cols: ['Species', 'Petal.Length'], names_to: 'name', values_to: 'value', values_drop_na: false, names_prefix: '' } },
+  { name: 'pivot-wider', field: 'names_from', state: { names_from: ['Species', 'Petal.Length'], values_from: ['Sepal.Length'], id_cols: [], values_fill: null, names_sep: '_', names_prefix: '', values_fn: null } },
+  { name: 'slice', field: 'by', state: { type: 'head', n: 5, prop: null, order_by: '', with_ties: true, weight_by: '', replace: false, rows: '1:5', by: ['Species', 'Petal.Length'] } },
+  { name: 'summarize', field: 'by', state: { summaries: [], by: ['Species', 'Petal.Length'] } },
+  { name: 'mutate', field: 'by', state: { mutations: [{ name: 'a', expr: '1' }], by: ['Species', 'Petal.Length'] } }
+];
+
+for (const { name, field, state } of MULTI) {
+  test(`${name}: a multi picker keeps every restored column through a stale list`, () => {
+    // A multi select never auto-picks, so everything in one was restored or
+    // chosen. `setOptions` FILTERS against the new list, which during a
+    // restore emptied the picker outright — no columns selected, nothing to
+    // pivot, no group-by, and no way back.
+    const b = mount(name);
+    b.setState(state);
+    b.columns(OTHER);
+    assert.deepStrictEqual(b.compose()[field], state[field]);
+
+    b.columns(IRIS);
+    assert.deepStrictEqual(b.compose()[field], state[field]);
+    b.close();
+  });
+
+  test(`${name}: a multi picker shows the columns the block holds`, () => {
+    // The chips are the only place the user can see what is selected; a
+    // picker that holds two columns and shows none is worse than either.
+    const b = mount(name);
+    b.setState(state);
+    b.columns(OTHER);
+    const holding = b.selects()
+      .map((s) => b.chipsOf(s))
+      .filter((chips) => chips.length);
+    assert.ok(
+      holding.some((chips) => state[field].every((c) => chips.includes(c))),
+      `no picker shows [${state[field]}]; chips are ${JSON.stringify(holding)}`
+    );
+    b.close();
+  });
+}
+
+test('summarize: a row that takes no column is not given one', () => {
+  // n() has no column, so "" is this row's answer and not a gap the select
+  // may fill from option 0. (Also covered end-to-end in test-shinytest2.R.)
+  const b = mount('summarize');
+  b.setState({
+    summaries: [
+      { type: 'simple', name: 'avg', func: 'mean', col: 'Species' },
+      { type: 'simple', name: 'n_rows', func: 'n', col: '' }
+    ],
+    by: []
+  });
+  b.columns(IRIS);
+  b.columns(OTHER);
+  b.columns(IRIS);
+
+  assert.deepStrictEqual(
+    b.compose().summaries.map((s) => s.col), ['Species', '']
+  );
+  b.close();
+});
+
+/* --- the reconcile must not resurrect a column the data really dropped -- */
+
+test('a pinned column that the new data does not have is still reported as picked', () => {
+  // Deliberate: the block keeps showing what the user chose rather than
+  // silently re-pointing at another column. R's expr builder is what
+  // decides how to fail on a missing column — quietly filtering on the
+  // wrong one is not an option available to it.
+  const b = mount('arrange');
+  b.columns(IRIS);
+  b.pickNth(0, 'Species');
+  b.columns(OTHER);
+  assert.deepStrictEqual(b.compose().columns, [{ column: 'Species', direction: 'asc' }]);
+  b.close();
+});
+
+test('picking again after the data changed follows the new data', () => {
+  const b = mount('arrange');
+  b.columns(IRIS);
+  b.pickNth(0, 'Species');
+  b.columns(OTHER);
+  b.pickNth(0, 'b');
+  assert.deepStrictEqual(b.compose().columns, [{ column: 'b', direction: 'asc' }]);
+  assert.strictEqual(b.submits.length, 2, 'each pick is a submit');
+  b.close();
+});

--- a/tests/js/harness.js
+++ b/tests/js/harness.js
@@ -1,0 +1,226 @@
+/* Mount a block's JavaScript in a headless DOM and drive it the way R does.
+ *
+ * The blocks in inst/js are the half of this package that R tests cannot
+ * reach: `testServer()` sees the custom messages R sends, never what the
+ * client does with them. The restore bugs live exactly there — in how a
+ * block reconciles a state push against a column-metadata push that may
+ * arrive before, after, or (while an upstream is still settling) with the
+ * wrong columns in it. So the tests run the real files, through the real
+ * `Blockr.registerBlock()` wiring, against a real DOM.
+ *
+ * What is stubbed is only Shiny itself:
+ *   - `Shiny.inputBindings.register` captures the binding, so `initialize`,
+ *     `getValue` and `subscribe` are the ones R would call.
+ *   - `Shiny.addCustomMessageHandler` captures the handlers, so `send()`
+ *     dispatches by the same channel names R sends on (js-block.R).
+ *   - `Shiny.setInputValue` records `<id>_ready` announcements and lazy
+ *     value requests.
+ *
+ * Usage:
+ *   const b = mount('arrange');
+ *   b.setState({ columns: [{ column: 'Species', direction: 'asc' }] });
+ *   b.columns(['Sepal.Length', 'Species']);
+ *   assert.deepStrictEqual(b.compose().columns, [...]);
+ *   b.close();
+ */
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { Window } = require('happy-dom');
+
+const JS_DIR = path.join(__dirname, '..', '..', 'inst', 'js');
+
+const read = (file) => fs.readFileSync(path.join(JS_DIR, file), 'utf8');
+
+/* Objects built inside the window's realm have that realm's prototypes, which
+ * `deepStrictEqual` counts as a difference. Serializing is also the honest
+ * comparison: JSON is what Shiny puts on the wire. */
+const json = (x) => (x === undefined ? undefined : JSON.parse(JSON.stringify(x)));
+
+/**
+ * The scripts a block loads with, in R's order (js_block_ui): the two files
+ * every block gets, then the shared ones the block declares in its own
+ * "Depends on:" header. Reading the header rather than keeping a list here
+ * means a block that grows a dependency and forgets to declare it fails
+ * loudly in its own test instead of quietly loading something the browser
+ * would not have served it.
+ */
+const ALWAYS = ['blockr-core.js', 'settings-band.js'];
+
+const scriptsFor = (src) => {
+  const m = /Depends on:\s*(.+)/.exec(src);
+  const declared = m
+    ? m[1].split(',').map((s) => s.trim()).filter((s) => /\.js$/.test(s))
+    : [];
+  return ALWAYS.concat(declared.filter((f) => !ALWAYS.includes(f)));
+};
+
+/** Column metadata in the shape build_column_picker_meta() sends. */
+const columnMeta = (cols) => cols.map((c) => (
+  typeof c === 'string' ? { name: c, label: '', type: 'character' } : c
+));
+
+/**
+ * @param {string} name kebab-case block name, e.g. 'arrange' or 'filter'
+ * @param {{id?: string, columns?: Array<string|object>, state?: object,
+ *          beforeInit?: (send: Function) => void}} [opts]
+ */
+function mount(name, opts = {}) {
+  const id = opts.id || `${name}_input`;
+  const win = new Window({ url: 'http://localhost/' });
+
+  // Shiny + jQuery stand-ins, in the window's own realm so the block files
+  // (which are browser IIFEs reaching for globals) load unmodified.
+  win.eval(`
+    window.__handlers = {};
+    window.__inputs = [];
+    window.__binding = null;
+    window.Shiny = {
+      InputBinding: function () {},
+      inputBindings: { register: function (b) { window.__binding = b; } },
+      addCustomMessageHandler: function (n, f) { window.__handlers[n] = f; },
+      setInputValue: function (n, v) { window.__inputs.push({ name: n, value: v }); }
+    };
+    window.$ = window.jQuery = function () { return { find: function () { return []; } }; };
+  `);
+
+  const blockSrc = read(`${name}-block.js`);
+  for (const dep of scriptsFor(blockSrc)) win.eval(read(dep));
+  win.eval(blockSrc);
+
+  const doc = win.document;
+  doc.body.innerHTML = `<div id="${id}" class="${name}-block-container"></div>`;
+  const el = doc.getElementById(id);
+
+  const binding = win.__binding;
+  if (!binding) throw new Error(`${name}-block.js registered no input binding`);
+
+  /** Values Shiny would have received, one per submit. */
+  const submits = [];
+
+  const api = {
+    win,
+    doc,
+    el,
+    binding,
+    submits,
+
+    /** The block instance (only after mount() returns; see initialize below). */
+    get block() {
+      return el._block;
+    },
+
+    /** What the block would send to R right now, submitted or not. */
+    compose() {
+      return json(el._block._compose());
+    },
+
+    /** What Shiny reads off the binding — null until the block has submitted. */
+    value() {
+      return json(binding.getValue(el));
+    },
+
+    /** Dispatch a custom message on the channel R sends it on. */
+    send(channel, message) {
+      const handler = win.__handlers[channel];
+      if (!handler) throw new Error(`no handler registered for "${channel}"`);
+      handler(Object.assign({ id }, message));
+      return api;
+    },
+
+    /** R's `<name>-block-update` (js_block_state()). */
+    setState(state) {
+      return api.send(`${name}-block-update`, { state });
+    },
+
+    /** R's `<name>-columns` (build_column_picker_meta()). */
+    columns(cols) {
+      return api.send(`${name}-columns`, { columns: columnMeta(cols) });
+    },
+
+    /** join takes one column list per input rather than one per block. */
+    joinColumns(xCols, yCols) {
+      return api.send('join-columns', {
+        xColumns: columnMeta(xCols),
+        yColumns: columnMeta(yCols)
+      });
+    },
+
+    /** `<id>_ready` announcements the client made (js_block_ready_name()). */
+    readyAnnouncements() {
+      return json(Array.from(win.__inputs).filter((i) => i.name === `${id}_ready`));
+    },
+
+    /** Everything the client pushed back as a Shiny input. */
+    inputs() {
+      return json(Array.from(win.__inputs));
+    },
+
+    /**
+     * Every `.blockr-select` root in the block, in document order. Note that
+     * this includes value pickers, not just column pickers — in filter, index
+     * 0 is a row's column and index 1 its values.
+     */
+    selects() {
+      return Array.from(el.querySelectorAll('.blockr-select'));
+    },
+
+    /** What a single select shows — the label the user reads off the face. */
+    faceOf(select) {
+      return select.querySelector('.blockr-select__value').textContent.trim();
+    },
+
+    /** Faces of every single select (column pickers), in document order. */
+    faces() {
+      return Array.from(el.querySelectorAll('.blockr-select--single')).map(api.faceOf);
+    },
+
+    /** The chips a multi select shows, in order. */
+    chipsOf(select) {
+      return Array.from(select.querySelectorAll('.blockr-select__tag'))
+        .map((t) => t.getAttribute('data-value'));
+    },
+
+    /**
+     * Pick an option the way a user does: open the control, click the option.
+     * Goes through the widget's own event handlers, so it fires `onChange`
+     * exactly as a real pick would.
+     */
+    pick(select, value) {
+      select.querySelector('.blockr-select__control').click();
+      const dropdown = doc.getElementById(select.getAttribute('aria-owns'));
+      const opt = dropdown.querySelector(`.blockr-select__option[data-value="${value}"]`);
+      if (!opt) {
+        const offered = Array.from(dropdown.querySelectorAll('.blockr-select__option'))
+          .map((o) => o.getAttribute('data-value'));
+        throw new Error(`"${value}" is not offered; the select lists [${offered}]`);
+      }
+      opt.click();
+      return api;
+    },
+
+    /** Pick in the nth select of the block (0-based). */
+    pickNth(n, value) {
+      return api.pick(api.selects()[n], value);
+    },
+
+    close() {
+      win.close();
+    }
+  };
+
+  // Messages sent before the element binds take the `Blockr._enqueue` path
+  // and are replayed by `initialize` — the deferred dock panel case.
+  if (opts.beforeInit) opts.beforeInit(api.send);
+
+  binding.initialize(el);
+  binding.subscribe(el, () => submits.push(json(binding.getValue(el))));
+
+  if (opts.columns) api.columns(opts.columns);
+  if (opts.state) api.setState(opts.state);
+
+  return api;
+}
+
+module.exports = { mount, columnMeta };

--- a/tests/js/state-restore.test.js
+++ b/tests/js/state-restore.test.js
@@ -1,0 +1,349 @@
+/* The restore contract, for every block that has one.
+ *
+ * A board hands a block back its saved state as a `<name>-block-update`
+ * message and its column choices as a `<name>-columns` message, in an order
+ * nobody controls: both are Shiny observers, and the columns come from
+ * `data()`, which is whatever the upstream has managed to produce so far.
+ * What a block must guarantee across all of that:
+ *
+ *   1. round trip     — what R sent is what the block would send back
+ *   2. order-free     — state-then-columns and columns-then-state agree
+ *   3. silence        — neither message is a user edit, so neither submits
+ *   4. no clobber     — a column list from the wrong (still settling) frame
+ *                       does not rewrite the state, and the right one
+ *                       restores the block intact
+ *
+ * These are deliberately written against `_compose()` — the JSON R actually
+ * receives — and not against block internals, so they keep their meaning
+ * through a refactor of how any given block stores its rows.
+ */
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert');
+const { mount } = require('./harness.js');
+
+const IRIS = ['Sepal.Length', 'Sepal.Width', 'Petal.Length', 'Species'];
+/* The frame an upstream that has not restored yet still shows. */
+const STALE = ['x', 'y', 'z'];
+
+/**
+ * One entry per block: a state worth restoring, and the columns it names.
+ *
+ * `roundTrip: false` marks a block whose `_compose()` is not the identity on
+ * its own state — noted per block, not waved away.
+ */
+const BLOCKS = [
+  {
+    name: 'arrange',
+    state: { columns: [{ column: 'Species', direction: 'desc' }] }
+  },
+  {
+    name: 'rename',
+    state: { renames: { species_name: 'Species', width: 'Sepal.Width' } }
+  },
+  {
+    name: 'select',
+    state: { columns: ['Species', 'Sepal.Length'], exclude: true, distinct: false }
+  },
+  {
+    name: 'separate',
+    state: {
+      col: 'Species', into: ['genus', 'epithet'], sep: '_',
+      remove: true, convert: false
+    }
+  },
+  {
+    name: 'unite',
+    state: {
+      col: 'joined', cols: ['Species', 'Sepal.Length'], sep: '-',
+      remove: false, na_rm: true
+    }
+  },
+  {
+    name: 'filter',
+    state: {
+      conditions: [
+        { type: 'values', column: 'Species', values: ['setosa'], mode: 'exclude', colType: 'character' }
+      ],
+      operator: '&',
+      preserve_order: false
+    }
+  },
+  {
+    name: 'pivot-longer',
+    state: {
+      cols: ['Sepal.Length', 'Sepal.Width'], names_to: 'measure',
+      values_to: 'cm', values_drop_na: true, names_prefix: 'Sepal.'
+    }
+  },
+  {
+    name: 'pivot-wider',
+    state: {
+      names_from: ['Species'], values_from: ['Sepal.Length'], id_cols: [],
+      values_fill: null, names_sep: '.', names_prefix: 'v_', values_fn: 'mean'
+    }
+  },
+  {
+    name: 'slice',
+    state: {
+      type: 'max', n: 3, prop: null, order_by: 'Sepal.Length', with_ties: false,
+      // '' is not a value slice keeps: a cleared rows field means "use the
+      // default", and _compose() sends the default back.
+      weight_by: '', replace: false, rows: '1:5', by: ['Species']
+    }
+  },
+  {
+    name: 'summarize',
+    state: {
+      summaries: [{ type: 'simple', name: 'avg', func: 'mean', col: 'Sepal.Length' }],
+      by: ['Species']
+    }
+  },
+  {
+    name: 'mutate',
+    state: {
+      mutations: [{ name: 'ratio', expr: 'Sepal.Length / Sepal.Width' }],
+      by: ['Species']
+    }
+  }
+];
+
+/** The order R pushes in: state first, then columns (js-block.R priorities). */
+const restore = (name, state, columns = IRIS) => {
+  const b = mount(name);
+  b.setState(state);
+  b.columns(columns);
+  return b;
+};
+
+for (const { name, state } of BLOCKS) {
+  test(`${name}: state round-trips`, () => {
+    const b = restore(name, state);
+    assert.deepStrictEqual(b.compose(), state);
+    b.close();
+  });
+
+  test(`${name}: the two message orders agree`, () => {
+    const first = restore(name, state);
+
+    const second = mount(name);
+    second.columns(IRIS);
+    second.setState(state);
+
+    assert.deepStrictEqual(second.compose(), first.compose());
+    first.close();
+    second.close();
+  });
+
+  test(`${name}: a restore is silent`, () => {
+    // A submit here would write the client's reading of the state back over
+    // R's own: `js_block_state()` decomposes an input blob straight into the
+    // per-field reactiveVals, and arms `self_write` so the correcting echo
+    // never comes. Restoring a board must not talk back.
+    const b = restore(name, state);
+    assert.deepStrictEqual(b.submits, []);
+    assert.strictEqual(b.value(), null);
+    b.close();
+  });
+
+  test(`${name}: a column list from a still-settling upstream does not rewrite it`, () => {
+    const b = mount(name);
+    b.setState(state);
+    b.columns(STALE);
+    b.columns(IRIS);
+    assert.deepStrictEqual(b.compose(), state);
+    assert.deepStrictEqual(b.submits, []);
+    b.close();
+  });
+
+  test(`${name}: the restored state survives even if the columns win the race`, () => {
+    // R orders its pushes so this does not happen (js-block.R), but the
+    // client must not depend on that: a block that has already read a column
+    // list still has to take the state that follows.
+    const b = mount(name);
+    b.columns(IRIS);
+    b.setState(state);
+    assert.deepStrictEqual(b.compose(), state);
+    b.close();
+  });
+
+  test(`${name}: a repeated column list does not rewrite it either`, () => {
+    // The announce path re-sends both messages, so every block sees its
+    // columns at least twice on a deferred dock panel.
+    const b = restore(name, state);
+    b.columns(IRIS);
+    assert.deepStrictEqual(b.compose(), state);
+    assert.deepStrictEqual(b.submits, []);
+    b.close();
+  });
+}
+
+/* --- join: two inputs, so two of everything -------------------------- */
+
+const JOIN_STATE = {
+  type: 'left',
+  keys: [{ xCol: 'Species', op: '==', yCol: 'name' }],
+  exprs: [],
+  suffix_x: '.x',
+  suffix_y: '.y'
+};
+
+test('join: state round-trips once both column lists are known', () => {
+  const b = mount('join');
+  b.joinColumns(IRIS, ['name', 'rank']);
+  b.setState(JOIN_STATE);
+  assert.deepStrictEqual(b.compose(), JOIN_STATE);
+  b.close();
+});
+
+test('join: a key survives column lists that do not offer its columns', () => {
+  // Either input can still be settling, so a key row has to hold both of its
+  // columns through a list that carries neither. A join that quietly re-points
+  // at column 1 on each side joins on the wrong thing and produces a table
+  // that looks plausible.
+  const b = mount('join');
+  b.setState(JOIN_STATE);
+  b.joinColumns(STALE, STALE);
+  assert.deepStrictEqual(b.compose().keys, JOIN_STATE.keys);
+
+  b.joinColumns(IRIS, ['name', 'rank']);
+  assert.deepStrictEqual(b.compose(), JOIN_STATE);
+  assert.deepStrictEqual(b.submits, []);
+  b.close();
+});
+
+test('join: one side settling does not disturb the other', () => {
+  const b = mount('join');
+  b.setState(JOIN_STATE);
+  b.joinColumns(IRIS, STALE);
+  assert.deepStrictEqual(b.compose().keys, JOIN_STATE.keys);
+  b.close();
+});
+
+test('join: an unpicked key still follows the data', () => {
+  const b = mount('join');
+  b.joinColumns(IRIS, ['name', 'rank']);
+  const auto = b.compose().keys;
+  assert.deepStrictEqual(auto, [{ xCol: 'Sepal.Length', op: '==', yCol: 'name' }]);
+
+  b.joinColumns(STALE, STALE);
+  assert.deepStrictEqual(b.compose().keys, [{ xCol: 'x', op: '==', yCol: 'x' }]);
+  b.close();
+});
+
+/* --- when a block IS allowed to talk back ---------------------------- */
+
+test('a fresh summarize tells R about the column it picked for itself', () => {
+  // The other side of "a restore is silent": a block that auto-picks has to
+  // submit, or it shows a configured-looking row that R knows nothing about.
+  const b = mount('summarize');
+  b.columns(IRIS);
+  assert.strictEqual(b.submits.length, 1);
+  assert.deepStrictEqual(b.submits[0].summaries, [
+    { type: 'simple', name: 'mean_Sepal.Length', func: 'mean', col: 'Sepal.Length' }
+  ]);
+  b.close();
+});
+
+test('a fresh join tells R about the keys it picked for itself', () => {
+  const b = mount('join');
+  b.joinColumns(IRIS, ['name', 'rank']);
+  assert.strictEqual(b.submits.length, 1);
+  assert.deepStrictEqual(b.submits[0].keys, [
+    { xCol: 'Sepal.Length', op: '==', yCol: 'name' }
+  ]);
+  b.close();
+});
+
+test('summarize answers when it had to generate a name R did not send', () => {
+  // A normalization the client applies is news; R has to store the name it
+  // will see in the output.
+  const b = mount('summarize');
+  b.columns(IRIS);
+  b.submits.length = 0;
+  b.setState({ summaries: [{ type: 'simple', name: '', func: 'mean', col: 'Petal.Length' }], by: [] });
+  assert.deepStrictEqual(b.submits, [{
+    summaries: [{ type: 'simple', name: 'mean_Petal.Length', func: 'mean', col: 'Petal.Length' }],
+    by: []
+  }]);
+  b.close();
+});
+
+test('mutate does not answer a restore with a group-by it has not applied yet', () => {
+  // The submit used to fire halfway through setState, before `by` was
+  // restored, so it shipped the previous (empty) by — and R writes an input
+  // blob straight into its per-field reactiveVals, so the board's group-by
+  // was gone with no way back.
+  const b = mount('mutate');
+  b.columns(IRIS);
+  b.submits.length = 0;
+  b.setState({ mutations: [{ name: 'ratio', expr: 'Sepal.Length / Sepal.Width' }], by: ['Species'] });
+  for (const submitted of b.submits) {
+    assert.deepStrictEqual(submitted.by, ['Species'], 'submitted a stale group-by');
+  }
+  b.close();
+});
+
+test('a single group-by column arrives unboxed and is still not news', () => {
+  // jsonlite auto-unboxes, so R's `by = "Species"` reaches the client as a
+  // bare string while `_compose()` holds `["Species"]`. Those are the same
+  // value, and one group-by column is the ordinary case -- keying them apart
+  // made the guard fire on almost every real restore, echoing the state
+  // straight back and re-arming `self_write` against the next genuine push.
+  for (const name of ['mutate', 'summarize']) {
+    const rows = name === 'mutate'
+      ? { mutations: [{ name: 'ratio', expr: 'Sepal.Length / Sepal.Width' }] }
+      : { summaries: [{ type: 'simple', name: 'm', func: 'mean', col: 'Petal.Length' }] };
+    const b = mount(name);
+    b.columns(IRIS);
+    b.submits.length = 0;
+    b.setState(Object.assign({}, rows, { by: 'Species' }));
+    assert.deepStrictEqual(b.submits, [], `${name} answered an unboxed restore`);
+    assert.deepStrictEqual(b.compose().by, ['Species'], `${name} lost the group-by`);
+    b.close();
+  }
+});
+
+/* --- blocks with no columns of their own ----------------------------- */
+
+test('bind-rows: state round-trips (it has no column pickers to lose)', () => {
+  const b = mount('bind-rows');
+  b.setState({ id_name: 'source' });
+  assert.deepStrictEqual(b.compose(), { id_name: 'source' });
+  assert.deepStrictEqual(b.submits, []);
+  b.close();
+});
+
+/* --- the announce handshake ------------------------------------------ */
+
+test('a block with nothing queued announces itself so R re-sends', () => {
+  // blockr.core#317: on a deferred dock panel the state and columns pushes
+  // are dropped before this JS exists, and no client-side queue can catch a
+  // message dropped before the queue loaded. The announce is the only way
+  // back — see js_block_ready_name().
+  const b = mount('arrange');
+  assert.strictEqual(b.readyAnnouncements().length, 1);
+  b.close();
+});
+
+test('a block whose pushes were queued does not announce', () => {
+  // Messages that arrive before the element binds are parked by
+  // `Blockr._enqueue` and replayed on initialize; asking R to re-send on top
+  // of that is a wasted round trip on every restored board.
+  const b = mount('arrange', { id: 'arrange_input' });
+  b.close();
+
+  const queued = mount('arrange', {
+    id: 'arrange_input',
+    beforeInit: (send) => send('arrange-block-update', {
+      state: { columns: [{ column: 'Species', direction: 'asc' }] }
+    })
+  });
+  assert.deepStrictEqual(queued.readyAnnouncements(), []);
+  assert.deepStrictEqual(
+    queued.compose().columns, [{ column: 'Species', direction: 'asc' }],
+    'the queued state was not replayed on bind'
+  );
+  queued.close();
+});

--- a/tests/testthat/test-js.R
+++ b/tests/testthat/test-js.R
@@ -1,0 +1,32 @@
+# Half of every block is JavaScript, so half of its tests are too (tests/js/).
+# Running them from testthat as well means `devtools::test()` and CI see a red
+# light when a block's restore contract breaks, instead of a JS suite quietly
+# rotting next to a `npm test` nobody thinks to run.
+#
+# `npm install` first (devDependency: happy-dom); without it this skips.
+test_that("the blocks keep their restore contract (node --test)", {
+
+  skip_on_cran()
+
+  node <- Sys.which("node")
+  skip_if(!nzchar(node), "node is not installed")
+
+  js_dir <- testthat::test_path("..", "js")
+  skip_if(!dir.exists(js_dir), "tests/js is not present")
+
+  modules <- file.path(js_dir, "..", "..", "node_modules", "happy-dom")
+  skip_if(!dir.exists(modules), "happy-dom is not installed (npm install)")
+
+  files <- list.files(js_dir, pattern = "[.]test[.]js$", full.names = TRUE)
+  skip_if(!length(files), "no JS tests found")
+
+  out <- suppressWarnings(
+    system2(node, c("--test", shQuote(files)), stdout = TRUE, stderr = TRUE)
+  )
+  status <- attr(out, "status")
+
+  expect_true(
+    is.null(status) || identical(status, 0L),
+    info = paste(out, collapse = "\n")
+  )
+})


### PR DESCRIPTION
## The bug

Restored blocks came back pointing at the wrong columns, or at none.

A block read its column back out of the `Blockr.Select` widget after refreshing the widget's options, and stored whatever the widget said. A column picker has no `allowEmpty`, so an option list that does not carry the block's column slides the widget onto option 0 — and during a restore that list arrives routinely, because an upstream that has not restored yet still reports the old frame's columns. The authored column was gone before the real one arrived, and nothing brought it back: `setState()` rebuilds from R's message, and that message does not repeat. Multi-column pickers lost their columns outright, because `setOptions()` filters the selection against the new list.

Every block with a column picker was affected: `rename` renamed the wrong column, `filter` kept its values while re-pointing at another column, `join` joined on the wrong keys, `select`, `unite`, `pivot_longer`, `pivot_wider`, `slice` and `summarize` came back empty, and `arrange` and `separate` collapsed onto the first column.

## The fix

The block owns its column; the widget only shows it. `Blockr.reconcileColumn` tells a deliberate column (restored by the board or picked by the user) from one the select auto-picked: the first survives a list that does not offer it and lands back on its option when the real columns arrive, the second still follows the data. Every block with a column picker now routes through it.

This cuts the other way too — when an upstream really has removed the column, the block holds on to it and fails loudly instead of quietly transforming a different one.

Two more restore paths were writing over R's state:

- `summarize` and `join` auto-submit once they know their columns, and `summarize` and `mutate` did so again from `setState()`, which on a restore wrote the client's reading of the block over the state R had just sent. `mutate`'s fired before the group-by had been restored, so a restored `mutate` lost its `.by` for good. `Blockr.stateKey` makes them speak only when they have something to say that R did not already tell them; it ignores key order and the scalar/length-1-array split that jsonlite's auto-unboxing puts on the wire, so a single group-by column does not read as news.
- On the R side the column pushes now drop to a lower priority than the state push, so a block always learns what it is before it learns what columns exist.

## Tests

Half of every block is JavaScript, and `testServer()` sees only the messages R sends, never what the client does with them — so the tests are JavaScript too. `tests/js` mounts the real files in happy-dom, drives them through the real message channels, and asserts `_compose()`. `devtools::test()` runs them via `tests/testthat/test-js.R`, skipping when node or happy-dom is absent.

128 JS tests, green locally; `npx tsc` clean.